### PR TITLE
fix: prevent submitting the form when applying table filter

### DIFF
--- a/packages/cuba-react/src/ui/table/DataTableCustomFilter.tsx
+++ b/packages/cuba-react/src/ui/table/DataTableCustomFilter.tsx
@@ -125,6 +125,7 @@ class DataTableCustomFilterComponent<E extends WithId>
   @action
   handleSubmit = (e: FormEvent): void => {
     e.preventDefault();
+    e.stopPropagation();
 
     this.props.form.validateFields((err) => {
        if (!err) {


### PR DESCRIPTION
affects: @cuba-platform/react

applying custom filter in a DataTable placed inside a form
was causing the form to submit

ISSUES CLOSED: #32