### PR TITLE
Hide property if metadata not loaded (quickfix)

### DIFF
--- a/packages/cuba-react/src/ui/EntityProperty.tsx
+++ b/packages/cuba-react/src/ui/EntityProperty.tsx
@@ -20,12 +20,19 @@ const EntityPropertyFormattedValue = observer((props: Props) => {
       value,
       showLabel = true,
       hideIfEmpty = true,
+      mainStore,
     } = props;
+
     if (hideIfEmpty && value == null) {
       return null;
     }
     if (props.mainStore == null || props.mainStore!.messages == null || !showLabel) {
       return <div>{formatValue(toJS(value))}</div>;
+    }
+
+    // store not ready yet
+    if (!mainStore || !mainStore.messages || !mainStore.metadata || !mainStore.enums) {
+      return null;
     }
 
     const label: string = props.mainStore!.messages![entityName + '.' + propertyName];


### PR DESCRIPTION
affects: @cuba-platform/react

do not show entity property if metadata or other required data are not ready in main store

ISSUES CLOSED: #54