### PR TITLE
Use node js 12+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 os: linux
 
 node_js:
-  - '10.17'
+  - '12.14.1'
 
 services:
   - postgresql

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ You will be able to create CRUD screens using CUBA Studio UI.
 
 #### Installation
 
-Install [Node.js](https://nodejs.org/en/download/) 10.15+ and npm 6+ (usually comes with node).
+Install [Node.js](https://nodejs.org/en/download/) 12+ and npm 6+ (usually comes with node).
 
 Install the generator using npm package manager: 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "root",
   "private": true,
+  "engines": {
+    "node": ">=12",
+    "npm": ">=6"
+  },
   "devDependencies": {
     "@commitlint/cli": "^8.3.4",
     "@commitlint/config-conventional": "^8.3.4",

--- a/packages/cuba-rest-js/package.json
+++ b/packages/cuba-rest-js/package.json
@@ -28,7 +28,7 @@
     "typescript": "~3.7.4"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=12"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/front-generator/package.json
+++ b/packages/front-generator/package.json
@@ -7,7 +7,7 @@
     "gen-cuba-front": "bin/gen-cuba-front.js"
   },
   "engines": {
-    "node": ">=10.17"
+    "node": ">=12"
   },
   "scripts": {
     "build": "rimraf lib && tsc && node scripts/copy-templates.js",


### PR DESCRIPTION
affects: @cuba-platform/rest, @cuba-platform/front-generator

relates: #3

BREAKING CHANGE:
required nodejs version 12+