### PR TITLE
Property types, part II

### DIFF
--- a/packages/cuba-react-ui/package-lock.json
+++ b/packages/cuba-react-ui/package-lock.json
@@ -629,6 +629,15 @@
 				"csstype": "^2.2.0"
 			}
 		},
+		"@types/react-input-mask": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@types/react-input-mask/-/react-input-mask-2.0.5.tgz",
+			"integrity": "sha512-4wPehO42dCk2sMrAGGT/xIfUG5GVdmzyGalweW5EvJARNXgtoxQ9HnkgSkXlVKR3oLVIHlT/vXk/DUXV+WSPyw==",
+			"dev": true,
+			"requires": {
+				"@types/react": "*"
+			}
+		},
 		"@types/react-slick": {
 			"version": "0.23.4",
 			"resolved": "https://registry.npmjs.org/@types/react-slick/-/react-slick-0.23.4.tgz",

--- a/packages/cuba-react-ui/package-lock.json
+++ b/packages/cuba-react-ui/package-lock.json
@@ -266,21 +266,6 @@
 				}
 			}
 		},
-		"@cuba-platform/react-core": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@cuba-platform/react-core/-/react-core-0.1.0.tgz",
-			"integrity": "sha512-yATf2ycPeK80M+4tXsMdn9H2Dyb8PewNbnUK8bd1v9ua6+0B1bCInHI9rPjgrytRDlIU9D2C2/4JQjhepiC3bg==",
-			"dev": true,
-			"requires": {
-				"moment": "^2.24.0"
-			}
-		},
-		"@cuba-platform/rest": {
-			"version": "0.7.3",
-			"resolved": "https://registry.npmjs.org/@cuba-platform/rest/-/rest-0.7.3.tgz",
-			"integrity": "sha512-sk5zK7g9yI3zMvZIGKZYP+/LDdMnP2iDv+DyDMUcBV4bK2m/hhV2PEUPZCL792I9BgyL42NOxwd5k8/t0dbkDA==",
-			"dev": true
-		},
 		"@formatjs/intl-listformat": {
 			"version": "1.3.7",
 			"resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-1.3.7.tgz",

--- a/packages/cuba-react-ui/package.json
+++ b/packages/cuba-react-ui/package.json
@@ -15,6 +15,7 @@
     "mobx": "^4.13.0 || ^5.13.0",
     "mobx-react": "^5.4.4",
     "react": "^16.7.0",
+    "react-input-mask": "^2.0.4",
     "react-intl": "^3.3.2"
   },
   "devDependencies": {
@@ -23,6 +24,7 @@
     "@types/jest": "^24.0.18",
     "@types/moment-timezone": "^0.5.12",
     "@types/react": "^16.7.18",
+    "@types/react-input-mask": "^2.0.5",
     "antd": "^3.23.4",
     "autoprefixer": "^9.7.2",
     "copyfiles": "^2.1.1",

--- a/packages/cuba-react-ui/src/ui/FormField.less
+++ b/packages/cuba-react-ui/src/ui/FormField.less
@@ -1,0 +1,3 @@
+.inputnumber-field {
+  width: 100%;
+}

--- a/packages/cuba-react-ui/src/ui/FormField.tsx
+++ b/packages/cuba-react-ui/src/ui/FormField.tsx
@@ -6,6 +6,7 @@ import {FileUpload} from './FileUpload';
 import {EntitySelectField} from "./EntitySelectField";
 import {MainStoreInjected, DataCollectionStore, WithId, injectMainStore, getPropertyInfo, isFileProperty} from "@cuba-platform/react-core";
 import './FormField.less';
+import {UuidField} from "./form/UuidField";
 
 type Props = MainStoreInjected & {
   entityName: string
@@ -62,6 +63,8 @@ export const FormField = injectMainStore(observer((props: Props) => {
              />
     case 'double':
       return <InputNumber className='inputnumber-field' {...rest}/>
+    case 'uuid':
+      return <UuidField {...rest}/>
   }
   return <Input {...rest}/>;
 }));

--- a/packages/cuba-react-ui/src/ui/FormField.tsx
+++ b/packages/cuba-react-ui/src/ui/FormField.tsx
@@ -1,10 +1,11 @@
 import * as React from "react";
-import {Checkbox, DatePicker, Input, Select, TimePicker} from "antd";
+import {Checkbox, DatePicker, Input, InputNumber, Select, TimePicker} from "antd";
 import {observer} from "mobx-react";
 import {Cardinality, EnumInfo, EnumValueInfo, MetaPropertyInfo, PropertyType} from "@cuba-platform/rest"
 import {FileUpload} from './FileUpload';
 import {EntitySelectField} from "./EntitySelectField";
 import {MainStoreInjected, DataCollectionStore, WithId, injectMainStore, getPropertyInfo, isFileProperty} from "@cuba-platform/react-core";
+import './FormField.less';
 
 type Props = MainStoreInjected & {
   entityName: string
@@ -52,6 +53,15 @@ export const FormField = injectMainStore(observer((props: Props) => {
     case 'localTime':
     case 'offsetTime':
       return <TimePicker {...rest}/>
+    case 'int':
+      return <InputNumber min={JAVA_INTEGER_MIN_VALUE}
+                          max={JAVA_INTEGER_MAX_VALUE}
+                          precision={0}
+                          className='inputnumber-field'
+                          {...rest}
+             />
+    case 'double':
+      return <InputNumber className='inputnumber-field' {...rest}/>
   }
   return <Input {...rest}/>;
 }));
@@ -82,3 +92,6 @@ function getSelectMode(cardinality: Cardinality): "default" | "multiple" {
 function getAllowClear(propertyInfo: MetaPropertyInfo): boolean {
   return !propertyInfo.mandatory;
 }
+
+const JAVA_INTEGER_MIN_VALUE = -2_147_483_648;
+const JAVA_INTEGER_MAX_VALUE = 2_147_483_647;

--- a/packages/cuba-react-ui/src/ui/FormField.tsx
+++ b/packages/cuba-react-ui/src/ui/FormField.tsx
@@ -53,16 +53,27 @@ export const FormField = injectMainStore(observer((props: Props) => {
     case 'time':
     case 'localTime':
     case 'offsetTime':
-      return <TimePicker {...rest}/>
+      return <TimePicker {...rest}/>;
     case 'int':
       return <InputNumber min={JAVA_INTEGER_MIN_VALUE}
                           max={JAVA_INTEGER_MAX_VALUE}
                           precision={0}
                           className='inputnumber-field'
                           {...rest}
-             />
+             />;
     case 'double':
-      return <InputNumber className='inputnumber-field' {...rest}/>
+      return <InputNumber className='inputnumber-field' {...rest}/>;
+    case 'long': // TODO values > Number.MAX_SAFE_INTEGER are not currently supported https://github.com/cuba-platform/frontend/issues/99
+      return <InputNumber className='inputnumber-field'
+                          // TODO once values > Number.MAX_SAFE_INTEGER add validation agains Long.MIN_VALUE/MAX_VALUE
+                          precision={0}
+                          {...rest}
+             />;
+    case 'decimal': // TODO values > Number.MAX_SAFE_INTEGER are not currently supported https://github.com/cuba-platform/frontend/issues/99
+      return <InputNumber className='inputnumber-field'
+                          // TODO Add validation of precision/scale https://github.com/cuba-platform/frontend/issues/100
+                          {...rest}
+             />;
     case 'uuid':
       return <UuidField {...rest}/>
   }

--- a/packages/cuba-react-ui/src/ui/form/Field.tsx
+++ b/packages/cuba-react-ui/src/ui/form/Field.tsx
@@ -6,7 +6,15 @@ import {FormComponentProps, FormItemProps} from 'antd/lib/form';
 import {GetFieldDecoratorOptions} from 'antd/lib/form/Form';
 import {Msg} from '../Msg';
 import {FieldPermissionContainer} from './FieldPermssionContainer';
-import { MainStoreInjected, DataCollectionStore, WithId, injectMainStore } from "@cuba-platform/react-core";
+import {
+  MainStoreInjected,
+  DataCollectionStore,
+  WithId,
+  injectMainStore,
+  getPropertyInfo
+} from "@cuba-platform/react-core";
+import {MetaClassInfo} from "@cuba-platform/rest";
+import {uuidPattern} from "../../util/regex";
 
 type Props = MainStoreInjected & FormComponentProps & {
   entityName: string
@@ -27,18 +35,23 @@ export const Field = injectMainStore(observer((props: Props) => {
 
   const {getFieldDecorator} = props.form;
 
-  const {entityName, propertyName, optionsContainer, fieldDecoratorId, getFieldDecoratorOpts, formItemKey} = props;
+  const {
+    entityName, propertyName, optionsContainer, fieldDecoratorId, getFieldDecoratorOpts, formItemKey, mainStore
+  } = props;
 
   const formItemOpts: FormItemProps = {... props.formItemOpts};
   if (!formItemOpts.label) formItemOpts.label = <Msg entityName={entityName} propertyName={propertyName}/>;
 
   return (
-    <FieldPermissionContainer entityName={entityName} propertyName={propertyName} renderField={(isReadOnly) => {
+    <FieldPermissionContainer entityName={entityName} propertyName={propertyName} renderField={(isReadOnly: boolean) => {
 
       return <Form.Item key={formItemKey ? formItemKey : propertyName}
                         {...formItemOpts}>
 
-        {getFieldDecorator(fieldDecoratorId ? fieldDecoratorId : propertyName, getFieldDecoratorOpts)(
+        {getFieldDecorator(
+            fieldDecoratorId ? fieldDecoratorId : propertyName,
+          {...getDefaultOptions(mainStore?.metadata, entityName, propertyName), ...getFieldDecoratorOpts}
+        )(
           <FormField entityName={entityName}
                      propertyName={propertyName}
                      disabled={isReadOnly}
@@ -51,3 +64,21 @@ export const Field = injectMainStore(observer((props: Props) => {
 
 }));
 
+function getDefaultOptions(metadata: MetaClassInfo[] | undefined, entityName: string, propertyName: string): GetFieldDecoratorOptions {
+  if (!metadata) {
+    return {};
+  }
+
+  const propertyInfo = getPropertyInfo(metadata, entityName, propertyName);
+
+  if (propertyInfo?.type === 'uuid') {
+    return {
+      rules: [
+        { pattern: uuidPattern }
+      ],
+      validateTrigger: 'onSubmit'
+    };
+  }
+
+  return {};
+}

--- a/packages/cuba-react-ui/src/ui/form/InputWithMask.tsx
+++ b/packages/cuba-react-ui/src/ui/form/InputWithMask.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactInputMask, { Props as ReactInputMaskProps } from 'react-input-mask';
+import {Input} from 'antd';
+import {InputProps} from "antd/es/input";
+
+
+export const InputWithMask = (props: ReactInputMaskProps) => {
+  return (
+    <ReactInputMask {...props}>
+      {(inputProps: InputProps) => <Input {...inputProps}/>}
+    </ReactInputMask>
+  );
+};

--- a/packages/cuba-react-ui/src/ui/form/UuidField.tsx
+++ b/packages/cuba-react-ui/src/ui/form/UuidField.tsx
@@ -1,0 +1,19 @@
+import { InputWithMask } from "./InputWithMask";
+import React from "react";
+
+type Props = {
+  disabled?: boolean
+};
+
+export const UuidField = (props: Props) => {
+  return (
+    <InputWithMask mask='xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx'
+                   formatChars={{
+                     'x': '[0-9a-fA-F]',
+                     'M': '[0-5]', // UUID version
+                     'N': '[089ab]', // UUID variant
+                   }}
+                   {...props}
+    />
+  );
+};

--- a/packages/cuba-react-ui/src/ui/table/DataTable.tsx
+++ b/packages/cuba-react-ui/src/ui/table/DataTable.tsx
@@ -338,7 +338,7 @@ export class DataTable<E> extends React.Component<DataTableProps<E>> {
       bodyStyle: { overflowX: 'auto' },
       loading: status === 'LOADING',
       columns: this.generateColumnProps,
-      dataSource: items.slice(),
+      dataSource: toJS(items),
       onChange: this.onChange,
       pagination: this.paginationConfig,
       rowKey: record => this.constructRowKey(record),

--- a/packages/cuba-react-ui/src/ui/table/DataTableCell.tsx
+++ b/packages/cuba-react-ui/src/ui/table/DataTableCell.tsx
@@ -19,22 +19,25 @@ export const DataTableCell = <EntityType extends unknown>(props: DataTableCellPr
         disabled={true}
       />
     );
-  } else if (props.propertyInfo.attributeType === 'ENUM') {
+  }
+
+  if (props.propertyInfo.attributeType === 'ENUM') {
     return (
       <EnumCell text={props.text} propertyInfo={props.propertyInfo} mainStore={props.mainStore!}/>
     );
-  } else if (props.propertyInfo.attributeType === 'ASSOCIATION' && props.propertyInfo.cardinality === 'MANY_TO_MANY') {
+  }
+
+  if (props.propertyInfo.attributeType === 'ASSOCIATION' && props.propertyInfo.cardinality === 'MANY_TO_MANY') {
     const associatedEntities = props.record?.[props.propertyInfo.name as keyof EntityType] as unknown as SerializedEntityProps[];
     const displayValue = associatedEntities?.map(entity => entity._instanceName).join(', ');
     return (
       <div>{displayValue}</div>
     );
-    return '';
-  } else {
-    return (
-      <div>{toDisplayValue(props.text, props.propertyInfo)}</div>
-    );
   }
+
+  return (
+    <div>{toDisplayValue(props.text, props.propertyInfo)}</div>
+  );
 };
 
 const EnumCell = <EntityType extends unknown>(props: DataTableCellProps<EntityType>) => {

--- a/packages/cuba-react-ui/src/ui/table/DataTableHelpers.tsx
+++ b/packages/cuba-react-ui/src/ui/table/DataTableHelpers.tsx
@@ -1,6 +1,13 @@
 import {ColumnFilterItem, ColumnProps, FilterDropdownProps, PaginationConfig, SorterResult} from 'antd/es/table';
 import React from 'react';
-import {Condition, ConditionsGroup, EntityFilter, EnumInfo, EnumValueInfo, MetaPropertyInfo} from '@cuba-platform/rest';
+import {
+  Condition,
+  ConditionsGroup,
+  EntityFilter,
+  EnumInfo,
+  EnumValueInfo,
+  MetaPropertyInfo
+} from '@cuba-platform/rest';
 import {DataTableCell} from './DataTableCell';
 import {
   ComparisonType,
@@ -162,7 +169,7 @@ export function generateDataColumn<EntityType>(config: DataColumnConfig): Column
     dataIndex,
     sorter: enableSorter,
     key: propertyName as string,
-    render: text => renderCell(propertyInfo, text, mainStore)
+    render: (text, record) => renderCell<EntityType>(propertyInfo, text, mainStore, record)
   };
 
   if (enableFilter && isPropertyTypeSupported(propertyInfo)) {
@@ -266,11 +273,12 @@ export function generateCustomFilterDropdown(
  * @param text
  * @param mainStore
  */
-export function renderCell(propertyInfo: MetaPropertyInfo, text: any, mainStore: MainStore) {
-  return DataTableCell({
+export function renderCell<EntityType>(propertyInfo: MetaPropertyInfo, text: any, mainStore: MainStore, record: EntityType) {
+  return DataTableCell<EntityType>({
     text,
     propertyInfo,
-    mainStore
+    mainStore,
+    record
   });
 }
 

--- a/packages/cuba-react-ui/src/util/regex.test.ts
+++ b/packages/cuba-react-ui/src/util/regex.test.ts
@@ -1,0 +1,18 @@
+import {uuidPattern} from "./regex";
+
+describe('UUID regex', () => {
+  it('should match valid UUID', () => {
+    expect('6c85d42d-6ffb-4f23-b9b4-ef46eeb82d98'.match(uuidPattern)).toBeTruthy();
+    expect('2f63bf04-baa0-4a5b-adcf-5388724bc2bc'.match(uuidPattern)).toBeTruthy();
+    expect('89FE53CD-6390-4054-8239-B9F78BF8D348'.match(uuidPattern)).toBeTruthy();
+  });
+  it('should not match invalid UUID', () => {
+    expect('1mskirm3-3jdk-5j3n-dsf4-5jsncxzsifrw'.match(uuidPattern)).toBeFalsy();
+    expect('f63bf04-baa0-4a5b-adcf-5388724bc2bc'.match(uuidPattern)).toBeFalsy();
+    expect('2f63bf04baa04a5badcf5388724bc2bc'.match(uuidPattern)).toBeFalsy();
+    expect(''.match(uuidPattern)).toBeFalsy();
+  });
+  it('should match NIL UUID', () => {
+    expect('00000000-0000-0000-0000-000000000000'.match(uuidPattern)).toBeTruthy();
+  });
+});

--- a/packages/cuba-react-ui/src/util/regex.ts
+++ b/packages/cuba-react-ui/src/util/regex.ts
@@ -1,0 +1,4 @@
+/**
+ * Matches UUID v1-v5. Matches NIL UUID.
+ */
+export const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i;

--- a/packages/cuba-rest-js/src/model.ts
+++ b/packages/cuba-rest-js/src/model.ts
@@ -8,7 +8,7 @@ export type TemporalPropertyType =
 export type PropertyType = TemporalPropertyType |
   'string' | 'uuid'
   | 'byteArray'
-  | 'int' | 'double' | 'decimal'
+  | 'int' | 'long' | 'double' | 'decimal'
   | 'boolean';
 
 export interface SerializedEntityProps {

--- a/packages/front-generator/package-lock.json
+++ b/packages/front-generator/package-lock.json
@@ -100,7 +100,7 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://127.0.0.1:5080/tarballs/debug/4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
@@ -345,7 +345,7 @@
     },
     "append-transform": {
       "version": "1.0.0",
-      "resolved": "http://127.0.0.1:5080/tarballs/append-transform/1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
       "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
       "dev": true,
       "requires": {
@@ -354,13 +354,13 @@
     },
     "archy": {
       "version": "1.0.0",
-      "resolved": "http://127.0.0.1:5080/tarballs/archy/1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
     },
     "argparse": {
       "version": "1.0.10",
-      "resolved": "http://127.0.0.1:5080/tarballs/argparse/1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
@@ -566,7 +566,7 @@
     },
     "caching-transform": {
       "version": "3.0.2",
-      "resolved": "http://127.0.0.1:5080/tarballs/caching-transform/3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-3.0.2.tgz",
       "integrity": "sha512-Mtgcv3lh3U0zRii/6qVgQODdPA4G3zhG+jtbCWj39RXuUFTMzH0vcdMtaJS1jPowd+It2Pqr6y3NJMQqOqCE2w==",
       "dev": true,
       "requires": {
@@ -578,7 +578,7 @@
       "dependencies": {
         "make-dir": {
           "version": "2.1.0",
-          "resolved": "http://127.0.0.1:5080/tarballs/make-dir/2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
           "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
           "dev": true,
           "requires": {
@@ -588,7 +588,7 @@
         },
         "pify": {
           "version": "4.0.1",
-          "resolved": "http://127.0.0.1:5080/tarballs/pify/4.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
           "dev": true
         }
@@ -601,7 +601,7 @@
     },
     "camelcase": {
       "version": "5.3.1",
-      "resolved": "http://127.0.0.1:5080/tarballs/camelcase/5.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
@@ -689,7 +689,7 @@
     },
     "cliui": {
       "version": "5.0.0",
-      "resolved": "http://127.0.0.1:5080/tarballs/cliui/5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
       "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
       "dev": true,
       "requires": {
@@ -712,7 +712,7 @@
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "http://127.0.0.1:5080/tarballs/string-width/3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
@@ -723,7 +723,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "http://127.0.0.1:5080/tarballs/strip-ansi/5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
@@ -825,7 +825,7 @@
     },
     "cp-file": {
       "version": "6.2.0",
-      "resolved": "http://127.0.0.1:5080/tarballs/cp-file/6.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-6.2.0.tgz",
       "integrity": "sha512-fmvV4caBnofhPe8kOcitBwSn2f39QLjnAnGq3gO9dfd75mUytzKNZB1hde6QHunW2Rt+OwuBOMc3i1tNElbszA==",
       "dev": true,
       "requires": {
@@ -838,7 +838,7 @@
       "dependencies": {
         "make-dir": {
           "version": "2.1.0",
-          "resolved": "http://127.0.0.1:5080/tarballs/make-dir/2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
           "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
           "dev": true,
           "requires": {
@@ -848,7 +848,7 @@
         },
         "pify": {
           "version": "4.0.1",
-          "resolved": "http://127.0.0.1:5080/tarballs/pify/4.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
           "dev": true
         }
@@ -894,7 +894,7 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "http://127.0.0.1:5080/tarballs/decamelize/1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
@@ -919,7 +919,7 @@
     },
     "default-require-extensions": {
       "version": "2.0.0",
-      "resolved": "http://127.0.0.1:5080/tarballs/default-require-extensions/2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
       "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
       "dev": true,
       "requires": {
@@ -928,7 +928,7 @@
       "dependencies": {
         "strip-bom": {
           "version": "3.0.0",
-          "resolved": "http://127.0.0.1:5080/tarballs/strip-bom/3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         }
@@ -1027,7 +1027,7 @@
       "dependencies": {
         "semver": {
           "version": "6.3.0",
-          "resolved": "http://repository.haulmont.com:8587/nexus/content/groups/npm/semver/-/semver-6.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
@@ -1077,7 +1077,7 @@
     },
     "es6-error": {
       "version": "4.1.1",
-      "resolved": "http://127.0.0.1:5080/tarballs/es6-error/4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true
     },
@@ -1088,7 +1088,7 @@
     },
     "esprima": {
       "version": "4.0.1",
-      "resolved": "http://127.0.0.1:5080/tarballs/esprima/4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
@@ -1280,7 +1280,7 @@
     },
     "find-cache-dir": {
       "version": "2.1.0",
-      "resolved": "http://127.0.0.1:5080/tarballs/find-cache-dir/2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
       "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
       "dev": true,
       "requires": {
@@ -1291,7 +1291,7 @@
       "dependencies": {
         "make-dir": {
           "version": "2.1.0",
-          "resolved": "http://127.0.0.1:5080/tarballs/make-dir/2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
           "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
           "dev": true,
           "requires": {
@@ -1301,7 +1301,7 @@
         },
         "pify": {
           "version": "4.0.1",
-          "resolved": "http://127.0.0.1:5080/tarballs/pify/4.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
           "dev": true
         }
@@ -1340,7 +1340,7 @@
     },
     "foreground-child": {
       "version": "1.5.6",
-      "resolved": "http://127.0.0.1:5080/tarballs/foreground-child/1.5.6.tgz",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
       "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
       "dev": true,
       "requires": {
@@ -1350,7 +1350,7 @@
       "dependencies": {
         "cross-spawn": {
           "version": "4.0.2",
-          "resolved": "http://127.0.0.1:5080/tarballs/cross-spawn/4.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
           "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
           "dev": true,
           "requires": {
@@ -1391,7 +1391,7 @@
     },
     "get-caller-file": {
       "version": "2.0.5",
-      "resolved": "http://127.0.0.1:5080/tarballs/get-caller-file/2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
@@ -1485,7 +1485,7 @@
     },
     "globals": {
       "version": "11.12.0",
-      "resolved": "http://127.0.0.1:5080/tarballs/globals/11.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
@@ -1602,7 +1602,7 @@
     },
     "hasha": {
       "version": "3.0.0",
-      "resolved": "http://127.0.0.1:5080/tarballs/hasha/3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
       "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
       "dev": true,
       "requires": {
@@ -1644,7 +1644,7 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "http://127.0.0.1:5080/tarballs/imurmurhash/0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
@@ -1694,7 +1694,7 @@
     },
     "inquirer-autocomplete-prompt": {
       "version": "1.0.1",
-      "resolved": "http://repository.haulmont.com:8587/nexus/content/groups/npm/inquirer-autocomplete-prompt/-/inquirer-autocomplete-prompt-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/inquirer-autocomplete-prompt/-/inquirer-autocomplete-prompt-1.0.1.tgz",
       "integrity": "sha512-Y4V6ifAu9LNrNjcEtYq8YUKhrgmmufUn5fsDQqeWgHY8rEO6ZAQkNUiZtBm2kw2uUQlC9HdgrRCHDhTPPguH5A==",
       "requires": {
         "ansi-escapes": "^3.0.0",
@@ -1877,7 +1877,7 @@
     },
     "is-retry-allowed": {
       "version": "1.2.0",
-      "resolved": "http://repository.haulmont.com:8587/nexus/content/groups/npm/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
       "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
     },
     "is-scoped": {
@@ -1940,13 +1940,13 @@
     },
     "istanbul-lib-coverage": {
       "version": "2.0.5",
-      "resolved": "http://127.0.0.1:5080/tarballs/istanbul-lib-coverage/2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
       "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
       "dev": true
     },
     "istanbul-lib-hook": {
       "version": "2.0.7",
-      "resolved": "http://127.0.0.1:5080/tarballs/istanbul-lib-hook/2.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz",
       "integrity": "sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==",
       "dev": true,
       "requires": {
@@ -1955,7 +1955,7 @@
     },
     "istanbul-lib-instrument": {
       "version": "3.3.0",
-      "resolved": "http://127.0.0.1:5080/tarballs/istanbul-lib-instrument/3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
       "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
       "dev": true,
       "requires": {
@@ -1970,7 +1970,7 @@
       "dependencies": {
         "semver": {
           "version": "6.3.0",
-          "resolved": "http://127.0.0.1:5080/tarballs/semver/6.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
@@ -1978,7 +1978,7 @@
     },
     "istanbul-lib-report": {
       "version": "2.0.8",
-      "resolved": "http://127.0.0.1:5080/tarballs/istanbul-lib-report/2.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
       "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
       "dev": true,
       "requires": {
@@ -1989,7 +1989,7 @@
       "dependencies": {
         "make-dir": {
           "version": "2.1.0",
-          "resolved": "http://127.0.0.1:5080/tarballs/make-dir/2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
           "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
           "dev": true,
           "requires": {
@@ -1999,13 +1999,13 @@
         },
         "pify": {
           "version": "4.0.1",
-          "resolved": "http://127.0.0.1:5080/tarballs/pify/4.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
           "dev": true
         },
         "supports-color": {
           "version": "6.1.0",
-          "resolved": "http://127.0.0.1:5080/tarballs/supports-color/6.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
@@ -2016,7 +2016,7 @@
     },
     "istanbul-lib-source-maps": {
       "version": "3.0.6",
-      "resolved": "http://127.0.0.1:5080/tarballs/istanbul-lib-source-maps/3.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
       "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
       "dev": true,
       "requires": {
@@ -2029,7 +2029,7 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://127.0.0.1:5080/tarballs/debug/4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
@@ -2038,7 +2038,7 @@
         },
         "make-dir": {
           "version": "2.1.0",
-          "resolved": "http://127.0.0.1:5080/tarballs/make-dir/2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
           "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
           "dev": true,
           "requires": {
@@ -2048,13 +2048,13 @@
         },
         "pify": {
           "version": "4.0.1",
-          "resolved": "http://127.0.0.1:5080/tarballs/pify/4.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
           "dev": true
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "http://127.0.0.1:5080/tarballs/source-map/0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
@@ -2086,7 +2086,7 @@
     },
     "js-yaml": {
       "version": "3.13.1",
-      "resolved": "http://127.0.0.1:5080/tarballs/js-yaml/3.13.1.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
@@ -2096,7 +2096,7 @@
     },
     "jsesc": {
       "version": "2.5.2",
-      "resolved": "http://127.0.0.1:5080/tarballs/jsesc/2.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
@@ -2153,7 +2153,7 @@
     },
     "load-json-file": {
       "version": "4.0.0",
-      "resolved": "http://127.0.0.1:5080/tarballs/load-json-file/4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
       "requires": {
@@ -2165,7 +2165,7 @@
       "dependencies": {
         "parse-json": {
           "version": "4.0.0",
-          "resolved": "http://127.0.0.1:5080/tarballs/parse-json/4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
@@ -2175,7 +2175,7 @@
         },
         "strip-bom": {
           "version": "3.0.0",
-          "resolved": "http://127.0.0.1:5080/tarballs/strip-bom/3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         }
@@ -2197,7 +2197,7 @@
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
-      "resolved": "http://127.0.0.1:5080/tarballs/lodash.flattendeep/4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
@@ -2231,7 +2231,7 @@
     },
     "lru-cache": {
       "version": "4.1.5",
-      "resolved": "http://127.0.0.1:5080/tarballs/lru-cache/4.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
       "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
       "requires": {
@@ -2379,7 +2379,7 @@
     },
     "merge-source-map": {
       "version": "1.1.0",
-      "resolved": "http://127.0.0.1:5080/tarballs/merge-source-map/1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
       "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
       "dev": true,
       "requires": {
@@ -2388,7 +2388,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "http://127.0.0.1:5080/tarballs/source-map/0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
@@ -2596,7 +2596,7 @@
     },
     "nested-error-stacks": {
       "version": "2.1.0",
-      "resolved": "http://127.0.0.1:5080/tarballs/nested-error-stacks/2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
       "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
       "dev": true
     },
@@ -2675,7 +2675,7 @@
     },
     "nyc": {
       "version": "14.1.1",
-      "resolved": "http://127.0.0.1:5080/tarballs/nyc/14.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-14.1.1.tgz",
       "integrity": "sha512-OI0vm6ZGUnoGZv/tLdZ2esSVzDwUC88SNs+6JoSOMVxA+gKMB8Tk7jBwgemLx4O40lhhvZCVw1C+OYLOBOPXWw==",
       "dev": true,
       "requires": {
@@ -2708,7 +2708,7 @@
       "dependencies": {
         "make-dir": {
           "version": "2.1.0",
-          "resolved": "http://127.0.0.1:5080/tarballs/make-dir/2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
           "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
           "dev": true,
           "requires": {
@@ -2718,7 +2718,7 @@
         },
         "pify": {
           "version": "4.0.1",
-          "resolved": "http://127.0.0.1:5080/tarballs/pify/4.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
           "dev": true
         }
@@ -2831,7 +2831,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://127.0.0.1:5080/tarballs/os-homedir/1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
@@ -2868,7 +2868,7 @@
     },
     "package-hash": {
       "version": "3.0.0",
-      "resolved": "http://127.0.0.1:5080/tarballs/package-hash/3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-3.0.0.tgz",
       "integrity": "sha512-lOtmukMDVvtkL84rJHI7dpTYq+0rli8N2wlnqUcBuDWCfVhRUfOmnR9SsoHFMLpACvEV60dX7rd0rFaYDZI+FA==",
       "dev": true,
       "requires": {
@@ -2976,7 +2976,7 @@
     },
     "pkg-dir": {
       "version": "3.0.0",
-      "resolved": "http://127.0.0.1:5080/tarballs/pkg-dir/3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
       "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
       "dev": true,
       "requires": {
@@ -3016,7 +3016,7 @@
     },
     "pseudomap": {
       "version": "1.0.2",
-      "resolved": "http://127.0.0.1:5080/tarballs/pseudomap/1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
@@ -3117,7 +3117,7 @@
     },
     "release-zalgo": {
       "version": "1.0.0",
-      "resolved": "http://127.0.0.1:5080/tarballs/release-zalgo/1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
       "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
       "dev": true,
       "requires": {
@@ -3167,13 +3167,13 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "http://127.0.0.1:5080/tarballs/require-directory/2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "require-main-filename": {
       "version": "2.0.0",
-      "resolved": "http://127.0.0.1:5080/tarballs/require-main-filename/2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
@@ -3187,7 +3187,7 @@
     },
     "resolve-from": {
       "version": "4.0.0",
-      "resolved": "http://127.0.0.1:5080/tarballs/resolve-from/4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
     },
@@ -3273,7 +3273,7 @@
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "http://127.0.0.1:5080/tarballs/set-blocking/2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
@@ -3527,7 +3527,7 @@
     },
     "spawn-wrap": {
       "version": "1.4.3",
-      "resolved": "http://127.0.0.1:5080/tarballs/spawn-wrap/1.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.3.tgz",
       "integrity": "sha512-IgB8md0QW/+tWqcavuFgKYR/qIRvJkRLPJDFaoXtLLUaVcCDK0+HeFTkmQHj3eprcYhc+gOl0aEA1w7qZlYezw==",
       "dev": true,
       "requires": {
@@ -3577,7 +3577,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://127.0.0.1:5080/tarballs/sprintf-js/1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -3687,7 +3687,7 @@
     },
     "test-exclude": {
       "version": "5.2.3",
-      "resolved": "http://127.0.0.1:5080/tarballs/test-exclude/5.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
       "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
       "dev": true,
       "requires": {
@@ -3699,7 +3699,7 @@
       "dependencies": {
         "read-pkg": {
           "version": "3.0.0",
-          "resolved": "http://127.0.0.1:5080/tarballs/read-pkg/3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
@@ -3710,7 +3710,7 @@
         },
         "read-pkg-up": {
           "version": "4.0.0",
-          "resolved": "http://127.0.0.1:5080/tarballs/read-pkg-up/4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
           "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
           "dev": true,
           "requires": {
@@ -3779,7 +3779,7 @@
     },
     "to-fast-properties": {
       "version": "2.0.0",
-      "resolved": "http://127.0.0.1:5080/tarballs/to-fast-properties/2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
@@ -4020,7 +4020,7 @@
     },
     "uuid": {
       "version": "3.3.3",
-      "resolved": "http://127.0.0.1:5080/tarballs/uuid/3.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
       "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
       "dev": true
     },
@@ -4196,7 +4196,7 @@
     },
     "which-module": {
       "version": "2.0.0",
-      "resolved": "http://127.0.0.1:5080/tarballs/which-module/2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
@@ -4225,7 +4225,7 @@
     },
     "wrap-ansi": {
       "version": "5.1.0",
-      "resolved": "http://127.0.0.1:5080/tarballs/wrap-ansi/5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
       "dev": true,
       "requires": {
@@ -4248,7 +4248,7 @@
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "http://127.0.0.1:5080/tarballs/string-width/3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
@@ -4259,7 +4259,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "http://127.0.0.1:5080/tarballs/strip-ansi/5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
@@ -4275,7 +4275,7 @@
     },
     "write-file-atomic": {
       "version": "2.4.3",
-      "resolved": "http://127.0.0.1:5080/tarballs/write-file-atomic/2.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
       "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
       "dev": true,
       "requires": {
@@ -4291,19 +4291,19 @@
     },
     "y18n": {
       "version": "4.0.0",
-      "resolved": "http://127.0.0.1:5080/tarballs/y18n/4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
     },
     "yallist": {
       "version": "2.1.2",
-      "resolved": "http://127.0.0.1:5080/tarballs/yallist/2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
     "yargs": {
       "version": "13.3.0",
-      "resolved": "http://127.0.0.1:5080/tarballs/yargs/13.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
       "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
       "dev": true,
       "requires": {
@@ -4333,7 +4333,7 @@
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "http://127.0.0.1:5080/tarballs/string-width/3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
@@ -4344,7 +4344,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "http://127.0.0.1:5080/tarballs/strip-ansi/5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
@@ -4355,7 +4355,7 @@
     },
     "yargs-parser": {
       "version": "13.1.1",
-      "resolved": "http://127.0.0.1:5080/tarballs/yargs-parser/13.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
       "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
       "dev": true,
       "requires": {

--- a/packages/front-generator/src/common/model/cuba-model.ts
+++ b/packages/front-generator/src/common/model/cuba-model.ts
@@ -76,7 +76,8 @@ export interface EntityAttribute {
   column: string;
   mandatory: boolean;
   unique: boolean;
-  length: number;
+  length: number; // TODO VP: should be optional, but that would break polymer generator
+  mappedBy?: string;
   transient: boolean;
   temporalType?: TemporalType;
 }

--- a/packages/front-generator/src/generators/react-typescript/app/template/package.json
+++ b/packages/front-generator/src/generators/react-typescript/app/template/package.json
@@ -12,6 +12,7 @@
     "moment": "^2.23.0",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
+    "react-input-mask": "^2.0.4",
     "react-intl": "^3.3.2",
     "react-router-dom": "^4.3.1",
     "react-scripts": "~3.3.0"
@@ -29,6 +30,7 @@
     "@types/node": "^10.12.18",
     "@types/react": "^16.7.18",
     "@types/react-dom": "^16.0.11",
+    "@types/react-input-mask": "^2.0.5",
     "@types/react-router-dom": "^4.3.1",
     "typescript": "~3.7.4"
   },

--- a/packages/front-generator/src/generators/react-typescript/common/entity.ts
+++ b/packages/front-generator/src/generators/react-typescript/common/entity.ts
@@ -26,6 +26,8 @@ export function determineDisplayedAttributes(
       && attr.cardinality === 'ONE_TO_ONE'
       && (attr.mappedBy && attr.mappedBy.length > 0);
 
-    return !isOneToManyAssociation && !isOneToOneAssociationInverseSide;
+    const isByteArray = (attr.mappingType === 'DATATYPE' && attr.type?.fqn === 'byte[]');
+
+    return !isOneToManyAssociation && !isOneToOneAssociationInverseSide && !isByteArray;
   });
 }

--- a/packages/front-generator/src/generators/react-typescript/common/entity.ts
+++ b/packages/front-generator/src/generators/react-typescript/common/entity.ts
@@ -1,0 +1,31 @@
+import {Entity, EntityAttribute, ProjectModel, ViewProperty} from "../../../common/model/cuba-model";
+import {collectAttributesFromHierarchy} from "../../../common/model/cuba-model-utils";
+import {EntityTemplateModel, getEntityPath} from "./template-model";
+
+export function createEntityTemplateModel(entity: Entity, projectModel: ProjectModel) {
+  return {
+    ...entity,
+    path: getEntityPath(entity, projectModel)
+  };
+}
+
+export function determineDisplayedAttributes(
+  viewProperties: ViewProperty[], entity: EntityTemplateModel, projectModel: ProjectModel
+) {
+  return viewProperties.reduce((attrArr: EntityAttribute[], prop) => {
+    const attr = collectAttributesFromHierarchy(entity, projectModel).find(ea => ea.name === prop.name);
+    if (attr) {
+      attrArr.push(attr);
+    }
+    return attrArr;
+  }, []).filter((attr: EntityAttribute) => {
+    const isOneToManyAssociation = (attr.mappingType === 'ASSOCIATION' && attr.cardinality === 'ONE_TO_MANY');
+
+    const isOneToOneAssociationInverseSide =
+      attr.mappingType === 'ASSOCIATION'
+      && attr.cardinality === 'ONE_TO_ONE'
+      && (attr.mappedBy && attr.mappedBy.length > 0);
+
+    return !isOneToManyAssociation && !isOneToOneAssociationInverseSide;
+  });
+}

--- a/packages/front-generator/src/generators/react-typescript/entity-cards/index.ts
+++ b/packages/front-generator/src/generators/react-typescript/entity-cards/index.ts
@@ -7,7 +7,7 @@ import {EntityCardsTemplateModel} from "./template-model";
 import {elementNameToClass, unCapitalizeFirst} from "../../../common/utils";
 import {addToMenu} from "../common/menu";
 import {writeComponentI18nMessages} from '../common/i18n';
-import {createEntityTemplateModel, determineDisplayedAttributes} from "../common/entity";
+import {createEntityTemplateModel, getDisplayedAttributes} from "../common/entity";
 import {EntityTemplateModel} from "../common/template-model";
 import {ProjectModel} from "../../../common/model/cuba-model";
 
@@ -73,7 +73,7 @@ export function entityCardsAnswersToModel(
   answers: EntityCardsAnswers, dirShift: string | undefined, entity: EntityTemplateModel, projectModel: ProjectModel
 ): EntityCardsTemplateModel {
   const className = elementNameToClass(answers.componentName);
-  const attributes = determineDisplayedAttributes(answers.entityView.allProperties, entity, projectModel);
+  const attributes = getDisplayedAttributes(answers.entityView.allProperties, entity, projectModel);
   return {
     componentName: answers.componentName,
     className: className,

--- a/packages/front-generator/src/generators/react-typescript/entity-cards/template-model.ts
+++ b/packages/front-generator/src/generators/react-typescript/entity-cards/template-model.ts
@@ -1,8 +1,9 @@
 import {CommonTemplateModel} from "../common/template-model";
-import {Entity, View} from "../../../common/model/cuba-model";
+import {Entity, EntityAttribute, View} from "../../../common/model/cuba-model";
 
 export interface EntityCardsTemplateModel extends CommonTemplateModel {
   nameLiteral: string;
   entity: Entity,
   view: View,
+  attributes: EntityAttribute[]
 }

--- a/packages/front-generator/src/generators/react-typescript/entity-cards/template/EntityCards.tsx.ejs
+++ b/packages/front-generator/src/generators/react-typescript/entity-cards/template/EntityCards.tsx.ejs
@@ -9,7 +9,7 @@ import {EntityProperty} from "@cuba-platform/react-ui";
 export class <%= className %> extends React.Component {
 
   dataCollection = collection<<%= entity.className %>>(<%= entity.className %>.NAME, {view: '<%=view.name%>', sort: '-updateTs'});
-  fields = [<% view.allProperties.forEach(p => { %>
+  fields = [<% attributes.forEach(p => { %>
     '<%= p.name %>',
     <% }) %>
     ];

--- a/packages/front-generator/src/generators/react-typescript/entity-management/index.ts
+++ b/packages/front-generator/src/generators/react-typescript/entity-management/index.ts
@@ -12,7 +12,7 @@ import {EntityTemplateModel, getEntityPath} from "../common/template-model";
 import * as entityManagementEn from "./entity-management-en.json";
 import * as entityManagementRu from "./entity-management-ru.json";
 import {writeComponentI18nMessages} from "../common/i18n";
-import {createEntityTemplateModel, determineDisplayedAttributes} from "../common/entity";
+import {createEntityTemplateModel, getDisplayedAttributes} from "../common/entity";
 
 class ReactEntityManagementGenerator extends BaseGenerator<EntityManagementAnswers, EntityManagementTemplateModel, PolymerElementOptions> {
 
@@ -84,10 +84,10 @@ export function answersToManagementModel(answers: EntityManagementAnswers,
   const entity: EntityTemplateModel = createEntityTemplateModel(answers.entity, projectModel);
 
   const listAttributes: EntityAttribute[] =
-    determineDisplayedAttributes(answers.listView.allProperties, entity, projectModel);
+    getDisplayedAttributes(answers.listView.allProperties, entity, projectModel);
 
   const editAttributes: EntityAttribute[] =
-    determineDisplayedAttributes(answers.editView.allProperties, entity, projectModel);
+    getDisplayedAttributes(answers.editView.allProperties, entity, projectModel);
 
   const editRelations = getRelations(projectModel, editAttributes);
 

--- a/packages/front-generator/src/generators/react-typescript/entity-management/template-model.ts
+++ b/packages/front-generator/src/generators/react-typescript/entity-management/template-model.ts
@@ -18,6 +18,7 @@ export interface EntityManagementTemplateModel extends CommonTemplateModel {
   nameLiteral: string;
   entity: EntityTemplateModel,
   listView: View,
+  listAttributes: EntityAttribute[],
   editView: View,
   editAttributes: EntityAttribute[],
   editRelations: EditRelations,

--- a/packages/front-generator/src/generators/react-typescript/entity-management/template/EntityManagementBrowser.tsx.ejs
+++ b/packages/front-generator/src/generators/react-typescript/entity-management/template/EntityManagementBrowser.tsx.ejs
@@ -37,7 +37,7 @@ class <%= listComponentName %>Component extends React.Component<MainStoreInjecte
   dataCollection = collection<<%= entity.className %>>(<%= entity.className %>.NAME, {view: '<%= listView.name %>', sort: '-updateTs'});
 
   fields = [
-  <% listView.allProperties.forEach(p => { %>
+  <% listAttributes.forEach(p => { %>
     '<%= p.name %>',
   <% }) %>
   ];

--- a/packages/front-generator/src/generators/react-typescript/entity-management/template/EntityManagementEditor.tsx.ejs
+++ b/packages/front-generator/src/generators/react-typescript/entity-management/template/EntityManagementEditor.tsx.ejs
@@ -54,7 +54,7 @@ class <%= editComponentName %>Component extends React.Component<Props & WrappedC
   reactionDisposer: IReactionDisposer;
 
   fields = [
-  <% editView.allProperties.forEach(p => { %>
+  <% editAttributes.forEach(p => { %>
     '<%= p.name %>',
   <% }) %>
   ];

--- a/packages/front-generator/src/test/fixtures/entity-model--association-o2o.json
+++ b/packages/front-generator/src/test/fixtures/entity-model--association-o2o.json
@@ -1,0 +1,58 @@
+{
+  "name": "scr_AssociationO2OTestEntity",
+  "className": "AssociationO2OTestEntity",
+  "packageName": "com.company.scr.entity.test",
+  "dataStore": "_MAIN_",
+  "table": "SCR_ASSOCIATION_O2O_TEST_ENTITY",
+  "updatable": false,
+  "creatable": false,
+  "hasUuid": false,
+  "softDelete": false,
+  "versioned": false,
+  "embeddable": false,
+  "persistentEntity": true,
+  "replaceParent": false,
+  "systemLevel": false,
+  "namePattern": "%s|name",
+  "mappedSuperclass": false,
+  "fqn": "com.company.scr.entity.test.AssociationO2OTestEntity",
+  "imported": false,
+  "parentPackage": "com.haulmont.cuba.core.entity",
+  "parentClassName": "StandardEntity",
+  "attributes": [
+    {
+      "name": "datatypesTestEntity",
+      "type": {
+        "packageName": "com.company.scr.entity.test",
+        "className": "DatatypesTestEntity",
+        "fqn": "com.company.scr.entity.test.DatatypesTestEntity",
+        "label": "DatatypesTestEntity",
+        "entityName": "scr_DatatypesTestEntity"
+      },
+      "mappingType": "ASSOCIATION",
+      "cardinality": "ONE_TO_ONE",
+      "readOnly": false,
+      "mandatory": false,
+      "unique": false,
+      "mappedBy": "associationO2Oattr",
+      "transient": false
+    },
+    {
+      "name": "name",
+      "type": {
+        "packageName": "java.lang",
+        "className": "String",
+        "fqn": "java.lang.String",
+        "label": "String"
+      },
+      "mappingType": "DATATYPE",
+      "readOnly": false,
+      "column": "NAME",
+      "mandatory": false,
+      "unique": false,
+      "length": "255",
+      "transient": false
+    }
+  ],
+  "path": "cuba/entities/scr_AssociationO2OTestEntity"
+}

--- a/packages/front-generator/src/test/fixtures/entity-model--datatypes-test-entity.json
+++ b/packages/front-generator/src/test/fixtures/entity-model--datatypes-test-entity.json
@@ -1,0 +1,420 @@
+{
+  "name": "scr_DatatypesTestEntity",
+  "className": "DatatypesTestEntity",
+  "packageName": "com.company.scr.entity.test",
+  "dataStore": "_MAIN_",
+  "table": "SCR_DATATYPES_TEST_ENTITY",
+  "updatable": false,
+  "creatable": false,
+  "hasUuid": false,
+  "softDelete": false,
+  "versioned": false,
+  "embeddable": false,
+  "persistentEntity": true,
+  "replaceParent": false,
+  "systemLevel": false,
+  "namePattern": "%s|name",
+  "mappedSuperclass": false,
+  "fqn": "com.company.scr.entity.test.DatatypesTestEntity",
+  "imported": false,
+  "parentPackage": "com.haulmont.cuba.core.entity",
+  "parentClassName": "StandardEntity",
+  "attributes": [
+    {
+      "name": "bigDecimalAttr",
+      "type": {
+        "packageName": "java.math",
+        "className": "BigDecimal",
+        "fqn": "java.math.BigDecimal",
+        "label": "BigDecimal"
+      },
+      "mappingType": "DATATYPE",
+      "readOnly": false,
+      "column": "BIG_DECIMAL_ATTR",
+      "mandatory": false,
+      "unique": false,
+      "length": "255",
+      "transient": false
+    },
+    {
+      "name": "booleanAttr",
+      "type": {
+        "packageName": "java.lang",
+        "className": "Boolean",
+        "fqn": "java.lang.Boolean",
+        "label": "Boolean"
+      },
+      "mappingType": "DATATYPE",
+      "readOnly": false,
+      "column": "BOOLEAN_ATTR",
+      "mandatory": false,
+      "unique": false,
+      "length": "255",
+      "transient": false
+    },
+    {
+      "name": "byteArrayAttr",
+      "type": {
+        "packageName": "",
+        "className": "byte[]",
+        "fqn": "byte[]",
+        "label": "ByteArray"
+      },
+      "mappingType": "DATATYPE",
+      "readOnly": false,
+      "column": "BYTE_ARRAY_ATTR",
+      "mandatory": false,
+      "unique": false,
+      "length": "255",
+      "transient": false
+    },
+    {
+      "name": "dateAttr",
+      "type": {
+        "packageName": "java.util",
+        "className": "Date",
+        "fqn": "java.util.Date",
+        "label": "Date"
+      },
+      "mappingType": "DATATYPE",
+      "readOnly": false,
+      "column": "DATE_ATTR",
+      "mandatory": false,
+      "unique": false,
+      "length": "255",
+      "transient": false,
+      "temporalType": "DATE"
+    },
+    {
+      "name": "dateTimeAttr",
+      "type": {
+        "packageName": "java.util",
+        "className": "Date",
+        "fqn": "java.util.Date",
+        "label": "DateTime"
+      },
+      "mappingType": "DATATYPE",
+      "readOnly": false,
+      "column": "DATE_TIME_ATTR",
+      "mandatory": false,
+      "unique": false,
+      "length": "255",
+      "transient": false,
+      "temporalType": "TIMESTAMP"
+    },
+    {
+      "name": "doubleAttr",
+      "type": {
+        "packageName": "java.lang",
+        "className": "Double",
+        "fqn": "java.lang.Double",
+        "label": "Double"
+      },
+      "mappingType": "DATATYPE",
+      "readOnly": false,
+      "column": "DOUBLE_ATTR",
+      "mandatory": false,
+      "unique": false,
+      "length": "255",
+      "transient": false
+    },
+    {
+      "name": "integerAttr",
+      "type": {
+        "packageName": "java.lang",
+        "className": "Integer",
+        "fqn": "java.lang.Integer",
+        "label": "Integer"
+      },
+      "mappingType": "DATATYPE",
+      "readOnly": false,
+      "column": "INTEGER_ATTR",
+      "mandatory": false,
+      "unique": false,
+      "length": "255",
+      "transient": false
+    },
+    {
+      "name": "longAttr",
+      "type": {
+        "packageName": "java.lang",
+        "className": "Long",
+        "fqn": "java.lang.Long",
+        "label": "Long"
+      },
+      "mappingType": "DATATYPE",
+      "readOnly": false,
+      "column": "LONG_ATTR",
+      "mandatory": false,
+      "unique": false,
+      "length": "255",
+      "transient": false
+    },
+    {
+      "name": "stringAttr",
+      "type": {
+        "packageName": "java.lang",
+        "className": "String",
+        "fqn": "java.lang.String",
+        "label": "String"
+      },
+      "mappingType": "DATATYPE",
+      "readOnly": false,
+      "column": "STRING_ATTR",
+      "mandatory": false,
+      "unique": false,
+      "length": "255",
+      "transient": false
+    },
+    {
+      "name": "timeAttr",
+      "type": {
+        "packageName": "java.util",
+        "className": "Date",
+        "fqn": "java.util.Date",
+        "label": "Time"
+      },
+      "mappingType": "DATATYPE",
+      "readOnly": false,
+      "column": "TIME_ATTR",
+      "mandatory": false,
+      "unique": false,
+      "length": "255",
+      "transient": false,
+      "temporalType": "TIME"
+    },
+    {
+      "name": "uuidAttr",
+      "type": {
+        "packageName": "java.util",
+        "className": "UUID",
+        "fqn": "java.util.UUID",
+        "label": "UUID"
+      },
+      "mappingType": "DATATYPE",
+      "readOnly": false,
+      "column": "UUID_ATTR",
+      "mandatory": false,
+      "unique": false,
+      "length": "255",
+      "transient": false
+    },
+    {
+      "name": "localDateTimeAttr",
+      "type": {
+        "packageName": "java.time",
+        "className": "LocalDateTime",
+        "fqn": "java.time.LocalDateTime",
+        "label": "localDateTime"
+      },
+      "mappingType": "DATATYPE",
+      "readOnly": false,
+      "column": "LOCAL_DATE_TIME_ATTR",
+      "mandatory": false,
+      "unique": false,
+      "length": "255",
+      "transient": false
+    },
+    {
+      "name": "offsetDateTimeAttr",
+      "type": {
+        "packageName": "java.time",
+        "className": "OffsetDateTime",
+        "fqn": "java.time.OffsetDateTime",
+        "label": "offsetDateTime"
+      },
+      "mappingType": "DATATYPE",
+      "readOnly": false,
+      "column": "OFFSET_DATE_TIME_ATTR",
+      "mandatory": false,
+      "unique": false,
+      "length": "255",
+      "transient": false
+    },
+    {
+      "name": "localDateAttr",
+      "type": {
+        "packageName": "java.time",
+        "className": "LocalDate",
+        "fqn": "java.time.LocalDate",
+        "label": "localDate"
+      },
+      "mappingType": "DATATYPE",
+      "readOnly": false,
+      "column": "LOCAL_DATE_ATTR",
+      "mandatory": false,
+      "unique": false,
+      "length": "255",
+      "transient": false
+    },
+    {
+      "name": "localTimeAttr",
+      "type": {
+        "packageName": "java.time",
+        "className": "LocalTime",
+        "fqn": "java.time.LocalTime",
+        "label": "localTime"
+      },
+      "mappingType": "DATATYPE",
+      "readOnly": false,
+      "column": "LOCAL_TIME_ATTR",
+      "mandatory": false,
+      "unique": false,
+      "length": "255",
+      "transient": false
+    },
+    {
+      "name": "offsetTimeAttr",
+      "type": {
+        "packageName": "java.time",
+        "className": "OffsetTime",
+        "fqn": "java.time.OffsetTime",
+        "label": "offsetTime"
+      },
+      "mappingType": "DATATYPE",
+      "readOnly": false,
+      "column": "OFFSET_TIME_ATTR",
+      "mandatory": false,
+      "unique": false,
+      "length": "255",
+      "transient": false
+    },
+    {
+      "name": "enumAttr",
+      "type": {
+        "packageName": "com.company.scr.entity.test",
+        "className": "TestEnum",
+        "fqn": "com.company.scr.entity.test.TestEnum",
+        "label": "TestEnum"
+      },
+      "mappingType": "ENUM",
+      "readOnly": false,
+      "column": "ENUM_ATTR",
+      "mandatory": false,
+      "unique": false,
+      "length": "255",
+      "transient": false
+    },
+    {
+      "name": "associationO2Oattr",
+      "type": {
+        "packageName": "com.company.scr.entity.test",
+        "className": "AssociationO2OTestEntity",
+        "fqn": "com.company.scr.entity.test.AssociationO2OTestEntity",
+        "label": "AssociationO2OTestEntity",
+        "entityName": "scr_AssociationO2OTestEntity"
+      },
+      "mappingType": "ASSOCIATION",
+      "cardinality": "ONE_TO_ONE",
+      "readOnly": false,
+      "column": "ASSOCIATION_O2_OATTR_ID",
+      "mandatory": false,
+      "unique": false,
+      "mappedBy": "",
+      "transient": false
+    },
+    {
+      "name": "associationO2Mattr",
+      "type": {
+        "packageName": "com.company.scr.entity.test",
+        "className": "AssociationO2MTestEntity",
+        "fqn": "com.company.scr.entity.test.AssociationO2MTestEntity",
+        "label": "AssociationO2MTestEntity",
+        "entityName": "scr_AssociationO2MTestEntity"
+      },
+      "mappingType": "ASSOCIATION",
+      "cardinality": "ONE_TO_MANY",
+      "readOnly": false,
+      "mandatory": false,
+      "unique": false,
+      "mappedBy": "datatypesTestEntity",
+      "transient": false
+    },
+    {
+      "name": "associationM2Oattr",
+      "type": {
+        "packageName": "com.company.scr.entity.test",
+        "className": "AssociationM2OTestEntity",
+        "fqn": "com.company.scr.entity.test.AssociationM2OTestEntity",
+        "label": "AssociationM2OTestEntity",
+        "entityName": "scr_AssociationM2OTestEntity"
+      },
+      "mappingType": "ASSOCIATION",
+      "cardinality": "MANY_TO_ONE",
+      "readOnly": false,
+      "column": "ASSOCIATION_M2_OATTR_ID",
+      "mandatory": false,
+      "unique": false,
+      "transient": false
+    },
+    {
+      "name": "associationM2Mattr",
+      "type": {
+        "packageName": "com.company.scr.entity.test",
+        "className": "AssociationM2MTestEntity",
+        "fqn": "com.company.scr.entity.test.AssociationM2MTestEntity",
+        "label": "AssociationM2MTestEntity",
+        "entityName": "scr_AssociationM2MTestEntity"
+      },
+      "mappingType": "ASSOCIATION",
+      "cardinality": "MANY_TO_MANY",
+      "readOnly": false,
+      "mandatory": false,
+      "unique": false,
+      "mappedBy": "",
+      "transient": false
+    },
+    {
+      "name": "compositionO2Oattr",
+      "type": {
+        "packageName": "com.company.scr.entity.test",
+        "className": "CompositionO2OTestEntity",
+        "fqn": "com.company.scr.entity.test.CompositionO2OTestEntity",
+        "label": "CompositionO2OTestEntity",
+        "entityName": "scr_CompositionO2OTestEntity"
+      },
+      "mappingType": "COMPOSITION",
+      "cardinality": "ONE_TO_ONE",
+      "readOnly": false,
+      "column": "COMPOSITION_O2_OATTR_ID",
+      "mandatory": false,
+      "unique": false,
+      "mappedBy": "",
+      "transient": false
+    },
+    {
+      "name": "compositionO2Mattr",
+      "type": {
+        "packageName": "com.company.scr.entity.test",
+        "className": "CompositionO2MTestEntity",
+        "fqn": "com.company.scr.entity.test.CompositionO2MTestEntity",
+        "label": "CompositionO2MTestEntity",
+        "entityName": "scr_CompositionO2MTestEntity"
+      },
+      "mappingType": "COMPOSITION",
+      "cardinality": "ONE_TO_MANY",
+      "readOnly": false,
+      "mandatory": false,
+      "unique": false,
+      "mappedBy": "datatypesTestEntity",
+      "transient": false
+    },
+    {
+      "name": "name",
+      "type": {
+        "packageName": "java.lang",
+        "className": "String",
+        "fqn": "java.lang.String",
+        "label": "String"
+      },
+      "mappingType": "DATATYPE",
+      "readOnly": false,
+      "column": "NAME",
+      "mandatory": false,
+      "unique": false,
+      "length": "255",
+      "transient": false
+    }
+  ],
+  "path": "cuba/entities/scr_DatatypesTestEntity"
+}

--- a/packages/front-generator/src/test/fixtures/project-model--scr.json
+++ b/packages/front-generator/src/test/fixtures/project-model--scr.json
@@ -1,0 +1,24479 @@
+{
+  "project": {
+    "name": "sample-car-rent",
+    "namespace": "scr",
+    "modulePrefix": "app",
+    "modelPrefix": "app"
+  },
+  "entities": [
+    {
+      "name": "ScrUserInfo",
+      "className": "ScrUserInfo",
+      "packageName": "com.company.scr.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": false,
+      "mappedSuperclass": false,
+      "fqn": "com.company.scr.entity.ScrUserInfo",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "firstName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "lastName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "favouriteCars",
+          "type": {
+            "packageName": "com.company.scr.entity",
+            "className": "Car",
+            "fqn": "com.company.scr.entity.Car",
+            "label": "Car",
+            "entityName": "scr$Car"
+          },
+          "mappingType": "ASSOCIATION",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "scr_AssociationO2MTestEntity",
+      "className": "AssociationO2MTestEntity",
+      "packageName": "com.company.scr.entity.test",
+      "dataStore": "_MAIN_",
+      "table": "SCR_ASSOCIATION_O2M_TEST_ENTITY",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": false,
+      "namePattern": "%s|name",
+      "mappedSuperclass": false,
+      "fqn": "com.company.scr.entity.test.AssociationO2MTestEntity",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "datatypesTestEntity",
+          "type": {
+            "packageName": "com.company.scr.entity.test",
+            "className": "DatatypesTestEntity",
+            "fqn": "com.company.scr.entity.test.DatatypesTestEntity",
+            "label": "DatatypesTestEntity",
+            "entityName": "scr_DatatypesTestEntity"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "DATATYPES_TEST_ENTITY_ID",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "scr_AssociationM2MTestEntity",
+      "className": "AssociationM2MTestEntity",
+      "packageName": "com.company.scr.entity.test",
+      "dataStore": "_MAIN_",
+      "table": "SCR_ASSOCIATION_M2M_TEST_ENTITY",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": false,
+      "namePattern": "%s|name",
+      "mappedSuperclass": false,
+      "fqn": "com.company.scr.entity.test.AssociationM2MTestEntity",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "datatypesTestEntities",
+          "type": {
+            "packageName": "com.company.scr.entity.test",
+            "className": "DatatypesTestEntity",
+            "fqn": "com.company.scr.entity.test.DatatypesTestEntity",
+            "label": "DatatypesTestEntity",
+            "entityName": "scr_DatatypesTestEntity"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_MANY",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "mappedBy": "",
+          "transient": false
+        },
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "scr_AssociationM2OTestEntity",
+      "className": "AssociationM2OTestEntity",
+      "packageName": "com.company.scr.entity.test",
+      "dataStore": "_MAIN_",
+      "table": "SCR_ASSOCIATION_M2O_TEST_ENTITY",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": false,
+      "namePattern": "%s|name",
+      "mappedSuperclass": false,
+      "fqn": "com.company.scr.entity.test.AssociationM2OTestEntity",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "scr_CompositionO2MTestEntity",
+      "className": "CompositionO2MTestEntity",
+      "packageName": "com.company.scr.entity.test",
+      "dataStore": "_MAIN_",
+      "table": "SCR_COMPOSITION_O2M_TEST_ENTITY",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": false,
+      "namePattern": "%s|name",
+      "mappedSuperclass": false,
+      "fqn": "com.company.scr.entity.test.CompositionO2MTestEntity",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "datatypesTestEntity",
+          "type": {
+            "packageName": "com.company.scr.entity.test",
+            "className": "DatatypesTestEntity",
+            "fqn": "com.company.scr.entity.test.DatatypesTestEntity",
+            "label": "DatatypesTestEntity",
+            "entityName": "scr_DatatypesTestEntity"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "DATATYPES_TEST_ENTITY_ID",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "scr$TechnicalCertificate",
+      "className": "TechnicalCertificate",
+      "packageName": "com.company.scr.entity",
+      "dataStore": "_MAIN_",
+      "table": "SCR_TECHNICAL_CERTIFICATE",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": false,
+      "namePattern": "%s|certNumber",
+      "mappedSuperclass": false,
+      "fqn": "com.company.scr.entity.TechnicalCertificate",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "certNumber",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CERT_NUMBER",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "car",
+          "type": {
+            "packageName": "com.company.scr.entity",
+            "className": "Car",
+            "fqn": "com.company.scr.entity.Car",
+            "label": "Car",
+            "entityName": "scr$Car"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "ONE_TO_ONE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "mappedBy": "technicalCertificate",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "scr_DatatypesTestEntity",
+      "className": "DatatypesTestEntity",
+      "packageName": "com.company.scr.entity.test",
+      "dataStore": "_MAIN_",
+      "table": "SCR_DATATYPES_TEST_ENTITY",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": false,
+      "namePattern": "%s|name",
+      "mappedSuperclass": false,
+      "fqn": "com.company.scr.entity.test.DatatypesTestEntity",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "bigDecimalAttr",
+          "type": {
+            "packageName": "java.math",
+            "className": "BigDecimal",
+            "fqn": "java.math.BigDecimal",
+            "label": "BigDecimal"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "BIG_DECIMAL_ATTR",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "booleanAttr",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "BOOLEAN_ATTR",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "byteArrayAttr",
+          "type": {
+            "packageName": "",
+            "className": "byte[]",
+            "fqn": "byte[]",
+            "label": "ByteArray"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "BYTE_ARRAY_ATTR",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "dateAttr",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "DATE_ATTR",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false,
+          "temporalType": "DATE"
+        },
+        {
+          "name": "dateTimeAttr",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "DateTime"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "DATE_TIME_ATTR",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false,
+          "temporalType": "TIMESTAMP"
+        },
+        {
+          "name": "doubleAttr",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Double",
+            "fqn": "java.lang.Double",
+            "label": "Double"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "DOUBLE_ATTR",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "integerAttr",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "INTEGER_ATTR",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "longAttr",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Long",
+            "fqn": "java.lang.Long",
+            "label": "Long"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "LONG_ATTR",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "stringAttr",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "STRING_ATTR",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "timeAttr",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Time"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "TIME_ATTR",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false,
+          "temporalType": "TIME"
+        },
+        {
+          "name": "uuidAttr",
+          "type": {
+            "packageName": "java.util",
+            "className": "UUID",
+            "fqn": "java.util.UUID",
+            "label": "UUID"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "UUID_ATTR",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "localDateTimeAttr",
+          "type": {
+            "packageName": "java.time",
+            "className": "LocalDateTime",
+            "fqn": "java.time.LocalDateTime",
+            "label": "localDateTime"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "LOCAL_DATE_TIME_ATTR",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "offsetDateTimeAttr",
+          "type": {
+            "packageName": "java.time",
+            "className": "OffsetDateTime",
+            "fqn": "java.time.OffsetDateTime",
+            "label": "offsetDateTime"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "OFFSET_DATE_TIME_ATTR",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "localDateAttr",
+          "type": {
+            "packageName": "java.time",
+            "className": "LocalDate",
+            "fqn": "java.time.LocalDate",
+            "label": "localDate"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "LOCAL_DATE_ATTR",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "localTimeAttr",
+          "type": {
+            "packageName": "java.time",
+            "className": "LocalTime",
+            "fqn": "java.time.LocalTime",
+            "label": "localTime"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "LOCAL_TIME_ATTR",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "offsetTimeAttr",
+          "type": {
+            "packageName": "java.time",
+            "className": "OffsetTime",
+            "fqn": "java.time.OffsetTime",
+            "label": "offsetTime"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "OFFSET_TIME_ATTR",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "enumAttr",
+          "type": {
+            "packageName": "com.company.scr.entity.test",
+            "className": "TestEnum",
+            "fqn": "com.company.scr.entity.test.TestEnum",
+            "label": "TestEnum"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "column": "ENUM_ATTR",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "associationO2Oattr",
+          "type": {
+            "packageName": "com.company.scr.entity.test",
+            "className": "AssociationO2OTestEntity",
+            "fqn": "com.company.scr.entity.test.AssociationO2OTestEntity",
+            "label": "AssociationO2OTestEntity",
+            "entityName": "scr_AssociationO2OTestEntity"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "ONE_TO_ONE",
+          "readOnly": false,
+          "column": "ASSOCIATION_O2_OATTR_ID",
+          "mandatory": false,
+          "unique": false,
+          "mappedBy": "",
+          "transient": false
+        },
+        {
+          "name": "associationO2Mattr",
+          "type": {
+            "packageName": "com.company.scr.entity.test",
+            "className": "AssociationO2MTestEntity",
+            "fqn": "com.company.scr.entity.test.AssociationO2MTestEntity",
+            "label": "AssociationO2MTestEntity",
+            "entityName": "scr_AssociationO2MTestEntity"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "ONE_TO_MANY",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "mappedBy": "datatypesTestEntity",
+          "transient": false
+        },
+        {
+          "name": "associationM2Oattr",
+          "type": {
+            "packageName": "com.company.scr.entity.test",
+            "className": "AssociationM2OTestEntity",
+            "fqn": "com.company.scr.entity.test.AssociationM2OTestEntity",
+            "label": "AssociationM2OTestEntity",
+            "entityName": "scr_AssociationM2OTestEntity"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "ASSOCIATION_M2_OATTR_ID",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "associationM2Mattr",
+          "type": {
+            "packageName": "com.company.scr.entity.test",
+            "className": "AssociationM2MTestEntity",
+            "fqn": "com.company.scr.entity.test.AssociationM2MTestEntity",
+            "label": "AssociationM2MTestEntity",
+            "entityName": "scr_AssociationM2MTestEntity"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_MANY",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "mappedBy": "",
+          "transient": false
+        },
+        {
+          "name": "compositionO2Oattr",
+          "type": {
+            "packageName": "com.company.scr.entity.test",
+            "className": "CompositionO2OTestEntity",
+            "fqn": "com.company.scr.entity.test.CompositionO2OTestEntity",
+            "label": "CompositionO2OTestEntity",
+            "entityName": "scr_CompositionO2OTestEntity"
+          },
+          "mappingType": "COMPOSITION",
+          "cardinality": "ONE_TO_ONE",
+          "readOnly": false,
+          "column": "COMPOSITION_O2_OATTR_ID",
+          "mandatory": false,
+          "unique": false,
+          "mappedBy": "",
+          "transient": false
+        },
+        {
+          "name": "compositionO2Mattr",
+          "type": {
+            "packageName": "com.company.scr.entity.test",
+            "className": "CompositionO2MTestEntity",
+            "fqn": "com.company.scr.entity.test.CompositionO2MTestEntity",
+            "label": "CompositionO2MTestEntity",
+            "entityName": "scr_CompositionO2MTestEntity"
+          },
+          "mappingType": "COMPOSITION",
+          "cardinality": "ONE_TO_MANY",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "mappedBy": "datatypesTestEntity",
+          "transient": false
+        },
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "scr$FavoriteCar",
+      "className": "FavoriteCar",
+      "packageName": "com.company.scr.entity",
+      "dataStore": "_MAIN_",
+      "table": "SCR_FAVORITE_CAR",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": false,
+      "namePattern": "%s|car",
+      "mappedSuperclass": false,
+      "fqn": "com.company.scr.entity.FavoriteCar",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "car",
+          "type": {
+            "packageName": "com.company.scr.entity",
+            "className": "Car",
+            "fqn": "com.company.scr.entity.Car",
+            "label": "Car",
+            "entityName": "scr$Car"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "CAR_ID",
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "user",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "User",
+            "fqn": "com.haulmont.cuba.security.entity.User",
+            "label": "User",
+            "entityName": "sec$User"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "USER_ID",
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "notes",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NOTES",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "scr$Garage",
+      "className": "Garage",
+      "packageName": "com.company.scr.entity",
+      "dataStore": "_MAIN_",
+      "table": "SCR_GARAGE",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": false,
+      "namePattern": "%s|name",
+      "mappedSuperclass": false,
+      "fqn": "com.company.scr.entity.Garage",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NAME",
+          "mandatory": true,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "capacity",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CAPACITY",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "scr$Car",
+      "className": "Car",
+      "packageName": "com.company.scr.entity",
+      "dataStore": "_MAIN_",
+      "table": "SCR_CAR",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": false,
+      "namePattern": "%s - %s|manufacturer,model",
+      "mappedSuperclass": false,
+      "fqn": "com.company.scr.entity.Car",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "manufacturer",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "MANUFACTURER",
+          "mandatory": true,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "model",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "MODEL",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "regNumber",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "REG_NUMBER",
+          "mandatory": false,
+          "unique": false,
+          "length": "5",
+          "transient": false
+        },
+        {
+          "name": "purchaseDate",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "PURCHASE_DATE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false,
+          "temporalType": "DATE"
+        },
+        {
+          "name": "manufactureDate",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "DateTime"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "MANUFACTURE_DATE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false,
+          "temporalType": "TIMESTAMP"
+        },
+        {
+          "name": "wheelOnRight",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "WHEEL_ON_RIGHT",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "carType",
+          "type": {
+            "packageName": "com.company.scr.entity",
+            "className": "CarType",
+            "fqn": "com.company.scr.entity.CarType",
+            "label": "CarType"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "column": "CAR_TYPE",
+          "mandatory": true,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "ecoRank",
+          "type": {
+            "packageName": "com.company.scr.entity",
+            "className": "EcoRank",
+            "fqn": "com.company.scr.entity.EcoRank",
+            "label": "EcoRank"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "column": "ECO_RANK",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "garage",
+          "type": {
+            "packageName": "com.company.scr.entity",
+            "className": "Garage",
+            "fqn": "com.company.scr.entity.Garage",
+            "label": "Garage",
+            "entityName": "scr$Garage"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "GARAGE_ID",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "maxPassengers",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "MAX_PASSENGERS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "price",
+          "type": {
+            "packageName": "java.math",
+            "className": "BigDecimal",
+            "fqn": "java.math.BigDecimal",
+            "label": "BigDecimal"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "PRICE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "mileage",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Double",
+            "fqn": "java.lang.Double",
+            "label": "Double"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "MILEAGE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "technicalCertificate",
+          "type": {
+            "packageName": "com.company.scr.entity",
+            "className": "TechnicalCertificate",
+            "fqn": "com.company.scr.entity.TechnicalCertificate",
+            "label": "TechnicalCertificate",
+            "entityName": "scr$TechnicalCertificate"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "ONE_TO_ONE",
+          "readOnly": false,
+          "column": "TECHNICAL_CERTIFICATE_ID",
+          "mandatory": false,
+          "unique": false,
+          "mappedBy": "",
+          "transient": false
+        },
+        {
+          "name": "photo",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.entity",
+            "className": "FileDescriptor",
+            "fqn": "com.haulmont.cuba.core.entity.FileDescriptor",
+            "label": "FileDescriptor",
+            "entityName": "sys$FileDescriptor"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "PHOTO_ID",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "scr_CompositionO2OTestEntity",
+      "className": "CompositionO2OTestEntity",
+      "packageName": "com.company.scr.entity.test",
+      "dataStore": "_MAIN_",
+      "table": "SCR_COMPOSITION_O2O_TEST_ENTITY",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": false,
+      "namePattern": "%s|name",
+      "mappedSuperclass": false,
+      "fqn": "com.company.scr.entity.test.CompositionO2OTestEntity",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "scr$CarRent",
+      "className": "CarRent",
+      "packageName": "com.company.scr.entity",
+      "dataStore": "_MAIN_",
+      "table": "SCR_CAR_RENT",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": false,
+      "mappedSuperclass": false,
+      "fqn": "com.company.scr.entity.CarRent",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "car",
+          "type": {
+            "packageName": "com.company.scr.entity",
+            "className": "Car",
+            "fqn": "com.company.scr.entity.Car",
+            "label": "Car",
+            "entityName": "scr$Car"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "CAR_ID",
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "fromDate",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "FROM_DATE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false,
+          "temporalType": "DATE"
+        },
+        {
+          "name": "fromTime",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Time"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "FROM_TIME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false,
+          "temporalType": "TIME"
+        },
+        {
+          "name": "fromDateTime",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "DateTime"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "FROM_DATE_TIME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false,
+          "temporalType": "TIMESTAMP"
+        }
+      ]
+    },
+    {
+      "name": "scr_AssociationO2OTestEntity",
+      "className": "AssociationO2OTestEntity",
+      "packageName": "com.company.scr.entity.test",
+      "dataStore": "_MAIN_",
+      "table": "SCR_ASSOCIATION_O2O_TEST_ENTITY",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": false,
+      "namePattern": "%s|name",
+      "mappedSuperclass": false,
+      "fqn": "com.company.scr.entity.test.AssociationO2OTestEntity",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "datatypesTestEntity",
+          "type": {
+            "packageName": "com.company.scr.entity.test",
+            "className": "DatatypesTestEntity",
+            "fqn": "com.company.scr.entity.test.DatatypesTestEntity",
+            "label": "DatatypesTestEntity",
+            "entityName": "scr_DatatypesTestEntity"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "ONE_TO_ONE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "mappedBy": "associationO2Oattr",
+          "transient": false
+        },
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "scr$SparePart",
+      "className": "SparePart",
+      "packageName": "com.company.scr.entity",
+      "dataStore": "_MAIN_",
+      "table": "SCR_SPARE_PART",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": false,
+      "namePattern": "%s|name",
+      "mappedSuperclass": false,
+      "fqn": "com.company.scr.entity.SparePart",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "spareParts",
+          "type": {
+            "packageName": "com.company.scr.entity",
+            "className": "SparePart",
+            "fqn": "com.company.scr.entity.SparePart",
+            "label": "SparePart",
+            "entityName": "scr$SparePart"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "SPARE_PARTS_ID",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "scr$User",
+      "className": "ScrUser",
+      "packageName": "com.company.scr.entity",
+      "dataStore": "_MAIN_",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": true,
+      "systemLevel": false,
+      "namePattern": "#getCaption|login,name",
+      "mappedSuperclass": false,
+      "fqn": "com.company.scr.entity.ScrUser",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.security.entity",
+      "parentClassName": "User",
+      "attributes": [
+        {
+          "name": "phone",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "phone",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    }
+  ],
+  "enums": [
+    {
+      "className": "TestEnum",
+      "packageName": "com.company.scr.entity.test",
+      "fqn": "com.company.scr.entity.test.TestEnum",
+      "type": "String",
+      "values": [
+        {
+          "name": "NEW_VALUE",
+          "id": "A"
+        },
+        {
+          "name": "NEW_VALUE1",
+          "id": "B"
+        },
+        {
+          "name": "NEW_VALUE2",
+          "id": "C"
+        }
+      ]
+    },
+    {
+      "className": "CarType",
+      "packageName": "com.company.scr.entity",
+      "fqn": "com.company.scr.entity.CarType",
+      "type": "String",
+      "values": [
+        {
+          "name": "SEDAN",
+          "id": "SEDAN"
+        },
+        {
+          "name": "HATCHBACK",
+          "id": "HATCHBACK"
+        }
+      ]
+    },
+    {
+      "className": "EcoRank",
+      "packageName": "com.company.scr.entity",
+      "fqn": "com.company.scr.entity.EcoRank",
+      "type": "Integer",
+      "values": [
+        {
+          "name": "EURO1",
+          "id": 1
+        },
+        {
+          "name": "EURO2",
+          "id": 2
+        },
+        {
+          "name": "EURO3",
+          "id": 3
+        }
+      ]
+    }
+  ],
+  "baseProjectEntities": [
+    {
+      "name": "sys$InfoParamEntity",
+      "className": "InfoParamEntity",
+      "packageName": "com.haulmont.cuba.gui.app.core.showinfo",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "namePattern": "%s|keyValue",
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.gui.app.core.showinfo.InfoParamEntity",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "key",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "keyValue",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sec$ScreenComponentDescriptor",
+      "className": "ScreenComponentDescriptor",
+      "packageName": "com.haulmont.cuba.gui.components",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.gui.components.ScreenComponentDescriptor",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "parent",
+          "type": {
+            "packageName": "com.haulmont.cuba.gui.components",
+            "className": "ScreenComponentDescriptor",
+            "fqn": "com.haulmont.cuba.gui.components.ScreenComponentDescriptor",
+            "label": "ScreenComponentDescriptor",
+            "entityName": "sec$ScreenComponentDescriptor"
+          },
+          "mappingType": "ASSOCIATION",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "caption",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        }
+      ]
+    },
+    {
+      "name": "sys$ScheduledExecution",
+      "className": "ScheduledExecution",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "table": "SYS_SCHEDULED_EXECUTION",
+      "updatable": false,
+      "creatable": true,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.ScheduledExecution",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "createTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATE_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "createdBy",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATED_BY",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "sysTenantId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SYS_TENANT_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "task",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.entity",
+            "className": "ScheduledTask",
+            "fqn": "com.haulmont.cuba.core.entity.ScheduledTask",
+            "label": "ScheduledTask",
+            "entityName": "sys$ScheduledTask"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "TASK_ID",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "server",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SERVER",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "startTime",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "START_TIME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "finishTime",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "FINISH_TIME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "result",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "RESULT",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "durationSec",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Long",
+            "fqn": "java.lang.Long",
+            "label": "Long"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        }
+      ]
+    },
+    {
+      "name": "sys$EntityPropertyDiff",
+      "className": "EntityPropertyDiff",
+      "packageName": "com.haulmont.cuba.core.entity.diff",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.diff.EntityPropertyDiff",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        },
+        {
+          "name": "label",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        },
+        {
+          "name": "beforeString",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        },
+        {
+          "name": "afterString",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        },
+        {
+          "name": "beforeCaption",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        },
+        {
+          "name": "afterCaption",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        },
+        {
+          "name": "itemState",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.entity.diff.EntityPropertyDiff",
+            "className": "ItemState",
+            "fqn": "com.haulmont.cuba.core.entity.diff.EntityPropertyDiff.ItemState",
+            "label": "ItemState"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        }
+      ]
+    },
+    {
+      "name": "sys$Category",
+      "className": "Category",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "table": "SYS_CATEGORY",
+      "discriminator": "0",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "namePattern": "%s|localeName",
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.Category",
+      "imported": false,
+      "inheritanceType": "JOINED",
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NAME",
+          "mandatory": true,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "entityType",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ENTITY_TYPE",
+          "mandatory": true,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "isDefault",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "IS_DEFAULT",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "categoryAttrs",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.entity",
+            "className": "CategoryAttribute",
+            "fqn": "com.haulmont.cuba.core.entity.CategoryAttribute",
+            "label": "CategoryAttribute",
+            "entityName": "sys$CategoryAttribute"
+          },
+          "mappingType": "COMPOSITION",
+          "cardinality": "ONE_TO_MANY",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "mappedBy": "category",
+          "transient": false
+        },
+        {
+          "name": "localeNames",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "LOCALE_NAMES",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "localeName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        },
+        {
+          "name": "special",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SPECIAL",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sec$CustomConditionCreator",
+      "className": "CustomConditionCreator",
+      "packageName": "com.haulmont.cuba.gui.components.filter.descriptor",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.gui.components.filter.descriptor.CustomConditionCreator",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.gui.components.filter.descriptor",
+      "parentClassName": "AbstractConditionDescriptor",
+      "attributes": []
+    },
+    {
+      "className": "AbstractSearchFolder",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": true,
+      "fqn": "com.haulmont.cuba.core.entity.AbstractSearchFolder",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "Folder",
+      "attributes": [
+        {
+          "name": "filterComponentId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "FILTER_COMPONENT",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "filterXml",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "FILTER_XML",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "applyDefault",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "APPLY_DEFAULT",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "locName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        }
+      ]
+    },
+    {
+      "name": "sec$AbstractTarget",
+      "className": "AbstractPermissionTarget",
+      "packageName": "com.haulmont.cuba.gui.app.security.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.gui.app.security.entity.AbstractPermissionTarget",
+      "imported": false,
+      "attributes": [
+        {
+          "name": "id",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "caption",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "permissionValue",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sys$JmxInstance",
+      "className": "JmxInstance",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "table": "SYS_JMX_INSTANCE",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "namePattern": "#getCaption|nodeName,address",
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.JmxInstance",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "nodeName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NODE_NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "address",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ADDRESS",
+          "mandatory": true,
+          "unique": false,
+          "length": "500",
+          "transient": false
+        },
+        {
+          "name": "login",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "LOGIN",
+          "mandatory": true,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "password",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "PASSWORD",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sys$BaseIntegerIdEntity",
+      "className": "BaseIntegerIdEntity",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": false,
+      "mappedSuperclass": true,
+      "fqn": "com.haulmont.cuba.core.entity.BaseIntegerIdEntity",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseGenericIdEntity",
+      "attributes": [
+        {
+          "name": "id",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ID",
+          "mandatory": true,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sec$UiTarget",
+      "className": "UiPermissionTarget",
+      "packageName": "com.haulmont.cuba.gui.app.security.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.gui.app.security.entity.UiPermissionTarget",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.gui.app.security.entity",
+      "parentClassName": "AbstractPermissionTarget",
+      "attributes": [
+        {
+          "name": "permissionVariant",
+          "type": {
+            "packageName": "com.haulmont.cuba.gui.app.security.entity",
+            "className": "UiPermissionVariant",
+            "fqn": "com.haulmont.cuba.gui.app.security.entity.UiPermissionVariant",
+            "label": "UiPermissionVariant"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "screen",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "component",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sec$LoggedAttribute",
+      "className": "LoggedAttribute",
+      "packageName": "com.haulmont.cuba.security.entity",
+      "table": "SEC_LOGGED_ATTR",
+      "updatable": false,
+      "creatable": true,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.security.entity.LoggedAttribute",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "createTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATE_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "createdBy",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATED_BY",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "entity",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "LoggedEntity",
+            "fqn": "com.haulmont.cuba.security.entity.LoggedEntity",
+            "label": "LoggedEntity",
+            "entityName": "sec$LoggedEntity"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "ENTITY_ID",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sec$AbstractConditionDescriptor",
+      "className": "AbstractConditionDescriptor",
+      "packageName": "com.haulmont.cuba.gui.components.filter.descriptor",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.gui.components.filter.descriptor.AbstractConditionDescriptor",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "locCaption",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        },
+        {
+          "name": "treeCaption",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        }
+      ]
+    },
+    {
+      "name": "sec$Group",
+      "className": "Group",
+      "packageName": "com.haulmont.cuba.security.entity",
+      "table": "SEC_GROUP",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": false,
+      "namePattern": "%s|name",
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.security.entity.Group",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NAME",
+          "mandatory": true,
+          "unique": true,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "parent",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "Group",
+            "fqn": "com.haulmont.cuba.security.entity.Group",
+            "label": "Group",
+            "entityName": "sec$Group"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "PARENT_ID",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "hierarchyList",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "GroupHierarchy",
+            "fqn": "com.haulmont.cuba.security.entity.GroupHierarchy",
+            "label": "GroupHierarchy",
+            "entityName": "sec$GroupHierarchy"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "ONE_TO_MANY",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "mappedBy": "group",
+          "transient": false
+        },
+        {
+          "name": "constraints",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "Constraint",
+            "fqn": "com.haulmont.cuba.security.entity.Constraint",
+            "label": "Constraint",
+            "entityName": "sec$Constraint"
+          },
+          "mappingType": "COMPOSITION",
+          "cardinality": "ONE_TO_MANY",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "mappedBy": "group",
+          "transient": false
+        },
+        {
+          "name": "sessionAttributes",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "SessionAttribute",
+            "fqn": "com.haulmont.cuba.security.entity.SessionAttribute",
+            "label": "SessionAttribute",
+            "entityName": "sec$SessionAttribute"
+          },
+          "mappingType": "COMPOSITION",
+          "cardinality": "ONE_TO_MANY",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "mappedBy": "group",
+          "transient": false
+        },
+        {
+          "name": "sysTenantId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SYS_TENANT_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sec$CustomCondition",
+      "className": "CustomCondition",
+      "packageName": "com.haulmont.cuba.gui.components.filter.condition",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.gui.components.filter.condition.CustomCondition",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.gui.components.filter.condition",
+      "parentClassName": "AbstractCondition",
+      "attributes": []
+    },
+    {
+      "name": "sec$PropertyCondition",
+      "className": "PropertyCondition",
+      "packageName": "com.haulmont.cuba.gui.components.filter.condition",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.gui.components.filter.condition.PropertyCondition",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.gui.components.filter.condition",
+      "parentClassName": "AbstractCondition",
+      "attributes": []
+    },
+    {
+      "name": "sys$Folder",
+      "className": "Folder",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "table": "SYS_FOLDER",
+      "discriminator": "F",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.Folder",
+      "imported": false,
+      "inheritanceType": "JOINED",
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "parent",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.entity",
+            "className": "Folder",
+            "fqn": "com.haulmont.cuba.core.entity.Folder",
+            "label": "Folder",
+            "entityName": "sys$Folder"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "PARENT_ID",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "100",
+          "transient": false
+        },
+        {
+          "name": "sortOrder",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SORT_ORDER",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "tabName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "TAB_NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "sysTenantId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SYS_TENANT_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sec$Role",
+      "className": "Role",
+      "packageName": "com.haulmont.cuba.security.entity",
+      "table": "SEC_ROLE",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": false,
+      "namePattern": "%s [%s]|locName,name",
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.security.entity.Role",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NAME",
+          "mandatory": true,
+          "unique": true,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "locName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "LOC_NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "description",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "DESCRIPTION",
+          "mandatory": false,
+          "unique": false,
+          "length": "1000",
+          "transient": false
+        },
+        {
+          "name": "type",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "RoleType",
+            "fqn": "com.haulmont.cuba.security.entity.RoleType",
+            "label": "RoleType"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "column": "ROLE_TYPE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "defaultRole",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "IS_DEFAULT_ROLE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "sysTenantId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SYS_TENANT_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "securityScope",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SECURITY_SCOPE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "defaultScreenAccess",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "Access",
+            "fqn": "com.haulmont.cuba.security.entity.Access",
+            "label": "Access"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "column": "DEFAULT_SCREEN_ACCESS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "defaultEntityCreateAccess",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "Access",
+            "fqn": "com.haulmont.cuba.security.entity.Access",
+            "label": "Access"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "column": "DEFAULT_ENTITY_CREATE_ACCESS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "defaultEntityReadAccess",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "Access",
+            "fqn": "com.haulmont.cuba.security.entity.Access",
+            "label": "Access"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "column": "DEFAULT_ENTITY_READ_ACCESS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "defaultEntityUpdateAccess",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "Access",
+            "fqn": "com.haulmont.cuba.security.entity.Access",
+            "label": "Access"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "column": "DEFAULT_ENTITY_UPDATE_ACCESS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "defaultEntityDeleteAccess",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "Access",
+            "fqn": "com.haulmont.cuba.security.entity.Access",
+            "label": "Access"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "column": "DEFAULT_ENTITY_DELETE_ACCESS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "defaultEntityAttributeAccess",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "EntityAttrAccess",
+            "fqn": "com.haulmont.cuba.security.entity.EntityAttrAccess",
+            "label": "EntityAttrAccess"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "column": "DEFAULT_ENTITY_ATTR_ACCESS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "defaultSpecificAccess",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "Access",
+            "fqn": "com.haulmont.cuba.security.entity.Access",
+            "label": "Access"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "column": "DEFAULT_SPECIFIC_ACCESS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "permissions",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "Permission",
+            "fqn": "com.haulmont.cuba.security.entity.Permission",
+            "label": "Permission",
+            "entityName": "sec$Permission"
+          },
+          "mappingType": "COMPOSITION",
+          "cardinality": "ONE_TO_MANY",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "mappedBy": "role",
+          "transient": false
+        },
+        {
+          "name": "locSecurityScope",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        }
+      ]
+    },
+    {
+      "name": "sec$GroupHierarchy",
+      "className": "GroupHierarchy",
+      "packageName": "com.haulmont.cuba.security.entity",
+      "table": "SEC_GROUP_HIERARCHY",
+      "updatable": false,
+      "creatable": true,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.security.entity.GroupHierarchy",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "createTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATE_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "createdBy",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATED_BY",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "sysTenantId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SYS_TENANT_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "group",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "Group",
+            "fqn": "com.haulmont.cuba.security.entity.Group",
+            "label": "Group",
+            "entityName": "sec$Group"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "GROUP_ID",
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "parent",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "Group",
+            "fqn": "com.haulmont.cuba.security.entity.Group",
+            "label": "Group",
+            "entityName": "sec$Group"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "PARENT_ID",
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "level",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "HIERARCHY_LEVEL",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sys$ScreenAndComponent",
+      "className": "ScreenAndComponent",
+      "packageName": "com.haulmont.cuba.gui.app.core.categories",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.gui.app.core.categories.ScreenAndComponent",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "screen",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "component",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sys$AppPropertyEntity",
+      "className": "AppPropertyEntity",
+      "packageName": "com.haulmont.cuba.core.config",
+      "updatable": true,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.config.AppPropertyEntity",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "updateTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "updatedBy",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "parent",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.config",
+            "className": "AppPropertyEntity",
+            "fqn": "com.haulmont.cuba.core.config.AppPropertyEntity",
+            "label": "AppPropertyEntity",
+            "entityName": "sys$AppPropertyEntity"
+          },
+          "mappingType": "ASSOCIATION",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "defaultValue",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "currentValue",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "category",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "overridden",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "dataTypeName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "enumValues",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "secret",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "displayedCurrentValue",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        },
+        {
+          "name": "displayedDefaultValue",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        }
+      ]
+    },
+    {
+      "name": "sys$BaseDbGeneratedIdEntity",
+      "className": "BaseDbGeneratedIdEntity",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": false,
+      "mappedSuperclass": true,
+      "fqn": "com.haulmont.cuba.core.entity.BaseDbGeneratedIdEntity",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseGenericIdEntity",
+      "attributes": []
+    },
+    {
+      "name": "sec$Constraint",
+      "className": "Constraint",
+      "packageName": "com.haulmont.cuba.security.entity",
+      "table": "SEC_CONSTRAINT",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.security.entity.Constraint",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "checkType",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "ConstraintCheckType",
+            "fqn": "com.haulmont.cuba.security.entity.ConstraintCheckType",
+            "label": "ConstraintCheckType"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "column": "CHECK_TYPE",
+          "mandatory": true,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "operationType",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "ConstraintOperationType",
+            "fqn": "com.haulmont.cuba.security.entity.ConstraintOperationType",
+            "label": "ConstraintOperationType"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "column": "OPERATION_TYPE",
+          "mandatory": true,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "code",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CODE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "entityName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ENTITY_NAME",
+          "mandatory": true,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "joinClause",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "JOIN_CLAUSE",
+          "mandatory": false,
+          "unique": false,
+          "length": "500",
+          "transient": false
+        },
+        {
+          "name": "whereClause",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "WHERE_CLAUSE",
+          "mandatory": false,
+          "unique": false,
+          "length": "1000",
+          "transient": false
+        },
+        {
+          "name": "groovyScript",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "GROOVY_SCRIPT",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "filterXml",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "FILTER_XML",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "isActive",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "IS_ACTIVE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "group",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "Group",
+            "fqn": "com.haulmont.cuba.security.entity.Group",
+            "label": "Group",
+            "entityName": "sec$Group"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "GROUP_ID",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "sysTenantId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SYS_TENANT_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sys$KeyValueEntity",
+      "className": "KeyValueEntity",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.KeyValueEntity",
+      "imported": false,
+      "attributes": []
+    },
+    {
+      "name": "sys$Config",
+      "className": "Config",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "table": "SYS_CONFIG",
+      "updatable": true,
+      "creatable": true,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": true,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.Config",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "version",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "VERSION",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "createTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATE_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "createdBy",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATED_BY",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "updateTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "UPDATE_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "updatedBy",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "UPDATED_BY",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NAME",
+          "mandatory": true,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "value",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "VALUE_",
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sec$GroupCondition",
+      "className": "GroupCondition",
+      "packageName": "com.haulmont.cuba.gui.components.filter.condition",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.gui.components.filter.condition.GroupCondition",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.gui.components.filter.condition",
+      "parentClassName": "AbstractCondition",
+      "attributes": []
+    },
+    {
+      "name": "sec$AttributeTarget",
+      "className": "AttributeTarget",
+      "packageName": "com.haulmont.cuba.gui.app.security.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.gui.app.security.entity.AttributeTarget",
+      "imported": false,
+      "attributes": [
+        {
+          "name": "id",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "permissionVariant",
+          "type": {
+            "packageName": "com.haulmont.cuba.gui.app.security.entity",
+            "className": "AttributePermissionVariant",
+            "fqn": "com.haulmont.cuba.gui.app.security.entity.AttributePermissionVariant",
+            "label": "AttributePermissionVariant"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sec$PropertyConditionDescriptor",
+      "className": "PropertyConditionDescriptor",
+      "packageName": "com.haulmont.cuba.gui.components.filter.descriptor",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.gui.components.filter.descriptor.PropertyConditionDescriptor",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.gui.components.filter.descriptor",
+      "parentClassName": "AbstractConditionDescriptor",
+      "attributes": []
+    },
+    {
+      "name": "sec$HeaderConditionDescriptor",
+      "className": "HeaderConditionDescriptor",
+      "packageName": "com.haulmont.cuba.gui.components.filter.descriptor",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.gui.components.filter.descriptor.HeaderConditionDescriptor",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.gui.components.filter.descriptor",
+      "parentClassName": "AbstractConditionDescriptor",
+      "attributes": []
+    },
+    {
+      "name": "sys$EntityDiff",
+      "className": "EntityDiff",
+      "packageName": "com.haulmont.cuba.core.entity.diff",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.diff.EntityDiff",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "label",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        }
+      ]
+    },
+    {
+      "name": "sec$EntityLogAttr",
+      "className": "EntityLogAttr",
+      "packageName": "com.haulmont.cuba.security.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.security.entity.EntityLogAttr",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "logItem",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "EntityLogItem",
+            "fqn": "com.haulmont.cuba.security.entity.EntityLogItem",
+            "label": "EntityLogItem",
+            "entityName": "sec$EntityLog"
+          },
+          "mappingType": "ASSOCIATION",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "value",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "oldValue",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "valueId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "oldValueId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "messagesPack",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "displayValue",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        },
+        {
+          "name": "displayOldValue",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        },
+        {
+          "name": "displayName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        },
+        {
+          "name": "locValue",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        },
+        {
+          "name": "locOldValue",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        }
+      ]
+    },
+    {
+      "name": "sys$BaseLongIdEntity",
+      "className": "BaseLongIdEntity",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": false,
+      "mappedSuperclass": true,
+      "fqn": "com.haulmont.cuba.core.entity.BaseLongIdEntity",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseGenericIdEntity",
+      "attributes": [
+        {
+          "name": "id",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Long",
+            "fqn": "java.lang.Long",
+            "label": "Long"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ID",
+          "mandatory": true,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "jmxcontrol$ManagedBeanDomain",
+      "className": "ManagedBeanDomain",
+      "packageName": "com.haulmont.cuba.web.jmx.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.web.jmx.entity.ManagedBeanDomain",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sys$BaseStringIdEntity",
+      "className": "BaseStringIdEntity",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": false,
+      "mappedSuperclass": true,
+      "fqn": "com.haulmont.cuba.core.entity.BaseStringIdEntity",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseGenericIdEntity",
+      "attributes": []
+    },
+    {
+      "name": "sys$EntityBasicPropertyDiff",
+      "className": "EntityBasicPropertyDiff",
+      "packageName": "com.haulmont.cuba.core.entity.diff",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.diff.EntityBasicPropertyDiff",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity.diff",
+      "parentClassName": "EntityPropertyDiff",
+      "attributes": []
+    },
+    {
+      "name": "sys$AppFolder",
+      "className": "AppFolder",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "table": "SYS_APP_FOLDER",
+      "discriminator": "A",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": false,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.AppFolder",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "AbstractSearchFolder",
+      "attributes": [
+        {
+          "name": "visibilityScript",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "VISIBILITY_SCRIPT",
+          "mandatory": false,
+          "unique": false,
+          "length": "200",
+          "transient": false
+        },
+        {
+          "name": "quantityScript",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "QUANTITY_SCRIPT",
+          "mandatory": false,
+          "unique": false,
+          "length": "200",
+          "transient": false
+        },
+        {
+          "name": "quantity",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        }
+      ]
+    },
+    {
+      "name": "sys$LockDescriptor",
+      "className": "LockDescriptor",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "table": "SYS_LOCK_CONFIG",
+      "updatable": false,
+      "creatable": true,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.LockDescriptor",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "createTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATE_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "createdBy",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATED_BY",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NAME",
+          "mandatory": true,
+          "unique": false,
+          "length": "100",
+          "transient": false
+        },
+        {
+          "name": "timeoutSec",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "TIMEOUT_SEC",
+          "mandatory": true,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sys$CategorizedEntity",
+      "className": "CategorizedEntity",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": false,
+      "mappedSuperclass": true,
+      "fqn": "com.haulmont.cuba.core.entity.CategorizedEntity",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "category",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.entity",
+            "className": "Category",
+            "fqn": "com.haulmont.cuba.core.entity.Category",
+            "label": "Category",
+            "entityName": "sys$Category"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "CATEGORY_ID",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sys$EntitySnapshot",
+      "className": "EntitySnapshot",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "table": "SYS_ENTITY_SNAPSHOT",
+      "updatable": false,
+      "creatable": true,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.EntitySnapshot",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "createTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATE_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "createdBy",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATED_BY",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "sysTenantId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SYS_TENANT_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "viewXml",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "VIEW_XML",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "snapshotXml",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SNAPSHOT_XML",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "entityMetaClass",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ENTITY_META_CLASS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "snapshotDate",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SNAPSHOT_DATE",
+          "mandatory": true,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "author",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "User",
+            "fqn": "com.haulmont.cuba.security.entity.User",
+            "label": "User",
+            "entityName": "sec$User"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "AUTHOR_ID",
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "entity",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.entity",
+            "className": "ReferenceToEntity",
+            "fqn": "com.haulmont.cuba.core.entity.ReferenceToEntity",
+            "label": "ReferenceToEntity",
+            "entityName": "sys$ReferenceToEntity"
+          },
+          "mappingType": "EMBEDDED",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "label",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        },
+        {
+          "name": "changeDate",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        }
+      ]
+    },
+    {
+      "name": "sys$CategoryAttribute",
+      "className": "CategoryAttribute",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "table": "SYS_CATEGORY_ATTR",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "namePattern": "%s (%s)|localeName,code",
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.CategoryAttribute",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "category",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.entity",
+            "className": "Category",
+            "fqn": "com.haulmont.cuba.core.entity.Category",
+            "label": "Category",
+            "entityName": "sys$Category"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "CATEGORY_ID",
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "categoryEntityType",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CATEGORY_ENTITY_TYPE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NAME",
+          "mandatory": true,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "code",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CODE",
+          "mandatory": true,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "description",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "DESCRIPTION",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "enumeration",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ENUMERATION",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "dataType",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.app.dynamicattributes",
+            "className": "PropertyType",
+            "fqn": "com.haulmont.cuba.core.app.dynamicattributes.PropertyType",
+            "label": "PropertyType"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "column": "DATA_TYPE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "entityClass",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ENTITY_CLASS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "defaultEntity",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.entity",
+            "className": "ReferenceToEntity",
+            "fqn": "com.haulmont.cuba.core.entity.ReferenceToEntity",
+            "label": "ReferenceToEntity",
+            "entityName": "sys$ReferenceToEntity"
+          },
+          "mappingType": "EMBEDDED",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "orderNo",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ORDER_NO",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "screen",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SCREEN",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "required",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "REQUIRED",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "lookup",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "LOOKUP",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "targetScreens",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "TARGET_SCREENS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "defaultString",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "DEFAULT_STRING",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "defaultInt",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "DEFAULT_INT",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "defaultDouble",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Double",
+            "fqn": "java.lang.Double",
+            "label": "Double"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "DEFAULT_DOUBLE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "defaultDecimal",
+          "type": {
+            "packageName": "java.math",
+            "className": "BigDecimal",
+            "fqn": "java.math.BigDecimal",
+            "label": "BigDecimal"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "DEFAULT_DECIMAL",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "defaultBoolean",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "DEFAULT_BOOLEAN",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "defaultDate",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "DEFAULT_DATE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "defaultDateWithoutTime",
+          "type": {
+            "packageName": "java.time",
+            "className": "LocalDate",
+            "fqn": "java.time.LocalDate",
+            "label": "localDate"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "DEFAULT_DATE_WO_TIME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "defaultDateIsCurrent",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "DEFAULT_DATE_IS_CURRENT",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "width",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "WIDTH",
+          "mandatory": false,
+          "unique": false,
+          "length": "20",
+          "transient": false
+        },
+        {
+          "name": "rowsCount",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ROWS_COUNT",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "isCollection",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "IS_COLLECTION",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "whereClause",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "WHERE_CLAUSE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "joinClause",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "JOIN_CLAUSE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "filterXml",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "FILTER_XML",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "localeNames",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "LOCALE_NAMES",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "localeDescriptions",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "LOCALE_DESCRIPTIONS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "enumerationLocales",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ENUMERATION_LOCALES",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "attributeConfigurationJson",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ATTRIBUTE_CONFIGURATION_JSON",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "localeName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        },
+        {
+          "name": "localeDescription",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        },
+        {
+          "name": "enumerationLocale",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        },
+        {
+          "name": "configuration",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.entity",
+            "className": "CategoryAttributeConfiguration",
+            "fqn": "com.haulmont.cuba.core.entity.CategoryAttributeConfiguration",
+            "label": "CategoryAttributeConfiguration",
+            "entityName": "sys$CategoryAttributeConfiguration"
+          },
+          "mappingType": "ASSOCIATION",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        }
+      ]
+    },
+    {
+      "name": "stat$ThreadSnapshot",
+      "className": "ThreadSnapshot",
+      "packageName": "com.haulmont.cuba.web.app.ui.statistics",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.web.app.ui.statistics.ThreadSnapshot",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "status",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "cpu",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Double",
+            "fqn": "java.lang.Double",
+            "label": "Double"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "deadLocked",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "stackTrace",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sys$EntityStatistics",
+      "className": "EntityStatistics",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "table": "SYS_ENTITY_STATISTICS",
+      "updatable": true,
+      "creatable": true,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.EntityStatistics",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "createTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATE_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "createdBy",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATED_BY",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "updateTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "UPDATE_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "updatedBy",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "UPDATED_BY",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "instanceCount",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Long",
+            "fqn": "java.lang.Long",
+            "label": "Long"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "INSTANCE_COUNT",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "fetchUI",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "FETCH_UI",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "maxFetchUI",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "MAX_FETCH_UI",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "lazyCollectionThreshold",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "LAZY_COLLECTION_THRESHOLD",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "lookupScreenThreshold",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "LOOKUP_SCREEN_THRESHOLD",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sys$ReferenceToEntity",
+      "className": "ReferenceToEntity",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": true,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.ReferenceToEntity",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "EmbeddableEntity",
+      "attributes": [
+        {
+          "name": "entityId",
+          "type": {
+            "packageName": "java.util",
+            "className": "UUID",
+            "fqn": "java.util.UUID",
+            "label": "UUID"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ENTITY_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "stringEntityId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "STRING_ENTITY_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "intEntityId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "INT_ENTITY_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "longEntityId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Long",
+            "fqn": "java.lang.Long",
+            "label": "Long"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "LONG_ENTITY_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sys$BaseIdentityIdEntity",
+      "className": "BaseIdentityIdEntity",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": false,
+      "mappedSuperclass": true,
+      "fqn": "com.haulmont.cuba.core.entity.BaseIdentityIdEntity",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseDbGeneratedIdEntity",
+      "attributes": [
+        {
+          "name": "id",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Long",
+            "fqn": "java.lang.Long",
+            "label": "Long"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ID",
+          "mandatory": true,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sys$EntityCollectionPropertyDiff",
+      "className": "EntityCollectionPropertyDiff",
+      "packageName": "com.haulmont.cuba.core.entity.diff",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.diff.EntityCollectionPropertyDiff",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity.diff",
+      "parentClassName": "EntityPropertyDiff",
+      "attributes": []
+    },
+    {
+      "name": "sec$RememberMeToken",
+      "className": "RememberMeToken",
+      "packageName": "com.haulmont.cuba.security.entity",
+      "table": "SEC_REMEMBER_ME",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.security.entity.RememberMeToken",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "user",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "User",
+            "fqn": "com.haulmont.cuba.security.entity.User",
+            "label": "User",
+            "entityName": "sec$User"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "USER_ID",
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "token",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "TOKEN",
+          "mandatory": true,
+          "unique": false,
+          "length": "32",
+          "transient": false
+        },
+        {
+          "name": "createTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATE_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sec$FtsConditionDescriptor",
+      "className": "FtsConditionDescriptor",
+      "packageName": "com.haulmont.cuba.gui.components.filter.descriptor",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.gui.components.filter.descriptor.FtsConditionDescriptor",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.gui.components.filter.descriptor",
+      "parentClassName": "AbstractConditionDescriptor",
+      "attributes": []
+    },
+    {
+      "name": "sys$FtsQueue",
+      "className": "FtsQueue",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "table": "SYS_FTS_QUEUE",
+      "updatable": false,
+      "creatable": true,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.FtsQueue",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "createTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATE_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "createdBy",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATED_BY",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "entityId",
+          "type": {
+            "packageName": "java.util",
+            "className": "UUID",
+            "fqn": "java.util.UUID",
+            "label": "UUID"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ENTITY_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "stringEntityId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "STRING_ENTITY_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "intEntityId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "INT_ENTITY_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "longEntityId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Long",
+            "fqn": "java.lang.Long",
+            "label": "Long"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "LONG_ENTITY_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "entityName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ENTITY_NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "changeType",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.entity",
+            "className": "FtsChangeType",
+            "fqn": "com.haulmont.cuba.core.entity.FtsChangeType",
+            "label": "FtsChangeType"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "column": "CHANGE_TYPE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "sourceHost",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SOURCE_HOST",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "indexingHost",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "INDEXING_HOST",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "fake",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "FAKE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sys$CategoryAttributeValue",
+      "className": "CategoryAttributeValue",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "table": "SYS_ATTR_VALUE",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.CategoryAttributeValue",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "categoryAttribute",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.entity",
+            "className": "CategoryAttribute",
+            "fqn": "com.haulmont.cuba.core.entity.CategoryAttribute",
+            "label": "CategoryAttribute",
+            "entityName": "sys$CategoryAttribute"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "CATEGORY_ATTR_ID",
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "code",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CODE",
+          "mandatory": true,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "stringValue",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "STRING_VALUE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "intValue",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "INTEGER_VALUE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "doubleValue",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Double",
+            "fqn": "java.lang.Double",
+            "label": "Double"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "DOUBLE_VALUE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "decimalValue",
+          "type": {
+            "packageName": "java.math",
+            "className": "BigDecimal",
+            "fqn": "java.math.BigDecimal",
+            "label": "BigDecimal"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "DECIMAL_VALUE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "booleanValue",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "BOOLEAN_VALUE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "dateValue",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "DATE_VALUE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "dateWithoutTimeValue",
+          "type": {
+            "packageName": "java.time",
+            "className": "LocalDate",
+            "fqn": "java.time.LocalDate",
+            "label": "localDate"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "DATE_WO_TIME_VALUE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "entity",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.entity",
+            "className": "ReferenceToEntity",
+            "fqn": "com.haulmont.cuba.core.entity.ReferenceToEntity",
+            "label": "ReferenceToEntity",
+            "entityName": "sys$ReferenceToEntity"
+          },
+          "mappingType": "EMBEDDED",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "entityValue",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.entity",
+            "className": "ReferenceToEntity",
+            "fqn": "com.haulmont.cuba.core.entity.ReferenceToEntity",
+            "label": "ReferenceToEntity",
+            "entityName": "sys$ReferenceToEntity"
+          },
+          "mappingType": "EMBEDDED",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "childValues",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.entity",
+            "className": "CategoryAttributeValue",
+            "fqn": "com.haulmont.cuba.core.entity.CategoryAttributeValue",
+            "label": "CategoryAttributeValue",
+            "entityName": "sys$CategoryAttributeValue"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "ONE_TO_MANY",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "mappedBy": "parent",
+          "transient": false
+        },
+        {
+          "name": "parent",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.entity",
+            "className": "CategoryAttributeValue",
+            "fqn": "com.haulmont.cuba.core.entity.CategoryAttributeValue",
+            "label": "CategoryAttributeValue",
+            "entityName": "sys$CategoryAttributeValue"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "PARENT_ID",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sec$OperationTarget",
+      "className": "OperationPermissionTarget",
+      "packageName": "com.haulmont.cuba.gui.app.security.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.gui.app.security.entity.OperationPermissionTarget",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.gui.app.security.entity",
+      "parentClassName": "AbstractPermissionTarget",
+      "attributes": [
+        {
+          "name": "createPermissionVariant",
+          "type": {
+            "packageName": "com.haulmont.cuba.gui.app.security.entity",
+            "className": "PermissionVariant",
+            "fqn": "com.haulmont.cuba.gui.app.security.entity.PermissionVariant",
+            "label": "PermissionVariant"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "readPermissionVariant",
+          "type": {
+            "packageName": "com.haulmont.cuba.gui.app.security.entity",
+            "className": "PermissionVariant",
+            "fqn": "com.haulmont.cuba.gui.app.security.entity.PermissionVariant",
+            "label": "PermissionVariant"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "updatePermissionVariant",
+          "type": {
+            "packageName": "com.haulmont.cuba.gui.app.security.entity",
+            "className": "PermissionVariant",
+            "fqn": "com.haulmont.cuba.gui.app.security.entity.PermissionVariant",
+            "label": "PermissionVariant"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "deletePermissionVariant",
+          "type": {
+            "packageName": "com.haulmont.cuba.gui.app.security.entity",
+            "className": "PermissionVariant",
+            "fqn": "com.haulmont.cuba.gui.app.security.entity.PermissionVariant",
+            "label": "PermissionVariant"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "localName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "entityMetaClassName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sys$Server",
+      "className": "Server",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "table": "SYS_SERVER",
+      "updatable": true,
+      "creatable": true,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "namePattern": "%s|name",
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.Server",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "createTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATE_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "createdBy",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATED_BY",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "updateTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "UPDATE_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "updatedBy",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "UPDATED_BY",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "running",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "IS_RUNNING",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "data",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "DATA",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sys$EmbeddableEntity",
+      "className": "EmbeddableEntity",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": false,
+      "mappedSuperclass": true,
+      "fqn": "com.haulmont.cuba.core.entity.EmbeddableEntity",
+      "imported": false,
+      "attributes": []
+    },
+    {
+      "name": "sec$Filter",
+      "className": "FilterEntity",
+      "packageName": "com.haulmont.cuba.security.entity",
+      "table": "SEC_FILTER",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "namePattern": "%s|name",
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.security.entity.FilterEntity",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "componentId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "COMPONENT",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "code",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CODE",
+          "mandatory": false,
+          "unique": false,
+          "length": "200",
+          "transient": false
+        },
+        {
+          "name": "xml",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "XML",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "user",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "User",
+            "fqn": "com.haulmont.cuba.security.entity.User",
+            "label": "User",
+            "entityName": "sec$User"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "USER_ID",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "globalDefault",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "GLOBAL_DEFAULT",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "sysTenantId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SYS_TENANT_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sys$SendingMessage",
+      "className": "SendingMessage",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "table": "SYS_SENDING_MESSAGE",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.SendingMessage",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "address",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ADDRESS_TO",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "from",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ADDRESS_FROM",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "cc",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ADDRESS_CC",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "bcc",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ADDRESS_BCC",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "caption",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CAPTION",
+          "mandatory": false,
+          "unique": false,
+          "length": "500",
+          "transient": false
+        },
+        {
+          "name": "contentText",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CONTENT_TEXT",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "contentTextFile",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.entity",
+            "className": "FileDescriptor",
+            "fqn": "com.haulmont.cuba.core.entity.FileDescriptor",
+            "label": "FileDescriptor",
+            "entityName": "sys$FileDescriptor"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "ONE_TO_ONE",
+          "readOnly": false,
+          "column": "CONTENT_TEXT_FILE_ID",
+          "mandatory": false,
+          "unique": false,
+          "mappedBy": "",
+          "transient": false
+        },
+        {
+          "name": "status",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.global",
+            "className": "SendingStatus",
+            "fqn": "com.haulmont.cuba.core.global.SendingStatus",
+            "label": "SendingStatus"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "column": "STATUS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "dateSent",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "DATE_SENT",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "attachmentsName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ATTACHMENTS_NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "deadline",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "DEADLINE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "attemptsCount",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ATTEMPTS_COUNT",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "attemptsMade",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ATTEMPTS_MADE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "attachments",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.entity",
+            "className": "SendingAttachment",
+            "fqn": "com.haulmont.cuba.core.entity.SendingAttachment",
+            "label": "SendingAttachment",
+            "entityName": "sys$SendingAttachment"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "ONE_TO_MANY",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "mappedBy": "message",
+          "transient": false
+        },
+        {
+          "name": "headers",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "EMAIL_HEADERS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "sysTenantId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SYS_TENANT_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "bodyContentType",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "BODY_CONTENT_TYPE",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "stat$PerformanceParameter",
+      "className": "PerformanceParameter",
+      "packageName": "com.haulmont.cuba.web.app.ui.statistics",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.web.app.ui.statistics.PerformanceParameter",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "parameterName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "displayName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "parameterGroup",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "currentStringValue",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        },
+        {
+          "name": "recentStringValue",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        },
+        {
+          "name": "averageStringValue",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        }
+      ]
+    },
+    {
+      "name": "sec$ScreenHistory",
+      "className": "ScreenHistoryEntity",
+      "packageName": "com.haulmont.cuba.security.entity",
+      "table": "SEC_SCREEN_HISTORY",
+      "updatable": false,
+      "creatable": true,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.security.entity.ScreenHistoryEntity",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "createTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATE_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "createdBy",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATED_BY",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "sysTenantId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SYS_TENANT_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "user",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "User",
+            "fqn": "com.haulmont.cuba.security.entity.User",
+            "label": "User",
+            "entityName": "sec$User"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "USER_ID",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "substitutedUser",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "User",
+            "fqn": "com.haulmont.cuba.security.entity.User",
+            "label": "User",
+            "entityName": "sec$User"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "SUBSTITUTED_USER_ID",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "caption",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CAPTION",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "url",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "URL",
+          "mandatory": false,
+          "unique": false,
+          "length": "4000",
+          "transient": false
+        },
+        {
+          "name": "entityRef",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.entity",
+            "className": "ReferenceToEntity",
+            "fqn": "com.haulmont.cuba.core.entity.ReferenceToEntity",
+            "label": "ReferenceToEntity",
+            "entityName": "sys$ReferenceToEntity"
+          },
+          "mappingType": "EMBEDDED",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "displayUser",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        }
+      ]
+    },
+    {
+      "name": "jmxcontrol$ManagedBeanOperationParameter",
+      "className": "ManagedBeanOperationParameter",
+      "packageName": "com.haulmont.cuba.web.jmx.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.web.jmx.entity.ManagedBeanOperationParameter",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "description",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "type",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "javaType",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sys$BaseGenericIdEntity",
+      "className": "BaseGenericIdEntity",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": false,
+      "mappedSuperclass": true,
+      "fqn": "com.haulmont.cuba.core.entity.BaseGenericIdEntity",
+      "imported": false,
+      "attributes": []
+    },
+    {
+      "name": "sec$AbstractCondition",
+      "className": "AbstractCondition",
+      "packageName": "com.haulmont.cuba.gui.components.filter.condition",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.gui.components.filter.condition.AbstractCondition",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "locCaption",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sec$EntityLog",
+      "className": "EntityLogItem",
+      "packageName": "com.haulmont.cuba.security.entity",
+      "table": "SEC_ENTITY_LOG",
+      "updatable": false,
+      "creatable": true,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.security.entity.EntityLogItem",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "createTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATE_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "createdBy",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATED_BY",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "sysTenantId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SYS_TENANT_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "eventTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "EVENT_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "user",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "User",
+            "fqn": "com.haulmont.cuba.security.entity.User",
+            "label": "User",
+            "entityName": "sec$User"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "USER_ID",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "type",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity.EntityLogItem",
+            "className": "Type",
+            "fqn": "com.haulmont.cuba.security.entity.EntityLogItem.Type",
+            "label": "Type"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "column": "CHANGE_TYPE",
+          "mandatory": false,
+          "unique": false,
+          "length": "1",
+          "transient": false
+        },
+        {
+          "name": "entity",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ENTITY",
+          "mandatory": false,
+          "unique": false,
+          "length": "100",
+          "transient": false
+        },
+        {
+          "name": "entityRef",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.entity",
+            "className": "ReferenceToEntity",
+            "fqn": "com.haulmont.cuba.core.entity.ReferenceToEntity",
+            "label": "ReferenceToEntity",
+            "entityName": "sys$ReferenceToEntity"
+          },
+          "mappingType": "EMBEDDED",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "entityInstanceName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ENTITY_INSTANCE_NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "attributes",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "EntityLogAttr",
+            "fqn": "com.haulmont.cuba.security.entity.EntityLogAttr",
+            "label": "EntityLogAttr",
+            "entityName": "sec$EntityLogAttr"
+          },
+          "mappingType": "ASSOCIATION",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        },
+        {
+          "name": "changes",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CHANGES",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "displayedEntityName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        }
+      ]
+    },
+    {
+      "name": "sec$Presentation",
+      "className": "Presentation",
+      "packageName": "com.haulmont.cuba.security.entity",
+      "table": "SEC_PRESENTATION",
+      "updatable": true,
+      "creatable": true,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "namePattern": "%s|name",
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.security.entity.Presentation",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "createTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATE_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "createdBy",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATED_BY",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "componentId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "COMPONENT",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "xml",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "XML",
+          "mandatory": false,
+          "unique": false,
+          "length": "4000",
+          "transient": false
+        },
+        {
+          "name": "user",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "User",
+            "fqn": "com.haulmont.cuba.security.entity.User",
+            "label": "User",
+            "entityName": "sec$User"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "USER_ID",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "autoSave",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "IS_AUTO_SAVE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "updateTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "UPDATE_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "updatedBy",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "UPDATED_BY",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "sysTenantId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SYS_TENANT_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sec$User",
+      "className": "User",
+      "packageName": "com.haulmont.cuba.security.entity",
+      "table": "SEC_USER",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": false,
+      "namePattern": "#getCaption|login,name",
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.security.entity.User",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "login",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "LOGIN",
+          "mandatory": true,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "loginLowerCase",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "LOGIN_LC",
+          "mandatory": true,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "password",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "PASSWORD",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "passwordEncryption",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "PASSWORD_ENCRYPTION",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "firstName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "FIRST_NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "lastName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "LAST_NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "middleName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "MIDDLE_NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "position",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "POSITION_",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "email",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "EMAIL",
+          "mandatory": false,
+          "unique": false,
+          "length": "100",
+          "transient": false
+        },
+        {
+          "name": "language",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "LANGUAGE_",
+          "mandatory": false,
+          "unique": false,
+          "length": "20",
+          "transient": false
+        },
+        {
+          "name": "timeZone",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "TIME_ZONE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "timeZoneAuto",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "TIME_ZONE_AUTO",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "active",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ACTIVE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "changePasswordAtNextLogon",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CHANGE_PASSWORD_AT_LOGON",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "group",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "Group",
+            "fqn": "com.haulmont.cuba.security.entity.Group",
+            "label": "Group",
+            "entityName": "sec$Group"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "GROUP_ID",
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "groupNames",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "GROUP_NAMES",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "userRoles",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "UserRole",
+            "fqn": "com.haulmont.cuba.security.entity.UserRole",
+            "label": "UserRole",
+            "entityName": "sec$UserRole"
+          },
+          "mappingType": "COMPOSITION",
+          "cardinality": "ONE_TO_MANY",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "mappedBy": "user",
+          "transient": false
+        },
+        {
+          "name": "substitutions",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "UserSubstitution",
+            "fqn": "com.haulmont.cuba.security.entity.UserSubstitution",
+            "label": "UserSubstitution",
+            "entityName": "sec$UserSubstitution"
+          },
+          "mappingType": "COMPOSITION",
+          "cardinality": "ONE_TO_MANY",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "mappedBy": "user",
+          "transient": false
+        },
+        {
+          "name": "ipMask",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "IP_MASK",
+          "mandatory": false,
+          "unique": false,
+          "length": "200",
+          "transient": false
+        },
+        {
+          "name": "sysTenantId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SYS_TENANT_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sec$UserSetting",
+      "className": "UserSetting",
+      "packageName": "com.haulmont.cuba.security.entity",
+      "table": "SEC_USER_SETTING",
+      "updatable": false,
+      "creatable": true,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.security.entity.UserSetting",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "createTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATE_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "createdBy",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATED_BY",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "user",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "User",
+            "fqn": "com.haulmont.cuba.security.entity.User",
+            "label": "User",
+            "entityName": "sec$User"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "USER_ID",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "clientType",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.global",
+            "className": "ClientType",
+            "fqn": "com.haulmont.cuba.core.global.ClientType",
+            "label": "ClientType"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "column": "CLIENT_TYPE",
+          "mandatory": false,
+          "unique": false,
+          "length": "1",
+          "transient": false
+        },
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "value",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "VALUE_",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sys$FileDescriptor",
+      "className": "FileDescriptor",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "table": "SYS_FILE",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "namePattern": "%s (%s)|name,createDate,extension",
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.FileDescriptor",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NAME",
+          "mandatory": true,
+          "unique": false,
+          "length": "500",
+          "transient": false
+        },
+        {
+          "name": "extension",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "EXT",
+          "mandatory": false,
+          "unique": false,
+          "length": "20",
+          "transient": false
+        },
+        {
+          "name": "size",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Long",
+            "fqn": "java.lang.Long",
+            "label": "Long"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "FILE_SIZE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "createDate",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATE_DATE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "sysTenantId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SYS_TENANT_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sys$StandardEntity",
+      "className": "StandardEntity",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "updatable": true,
+      "creatable": true,
+      "hasUuid": false,
+      "softDelete": true,
+      "versioned": true,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": false,
+      "mappedSuperclass": true,
+      "fqn": "com.haulmont.cuba.core.entity.StandardEntity",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "version",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "VERSION",
+          "mandatory": true,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "createTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATE_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "createdBy",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATED_BY",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "updateTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "UPDATE_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "updatedBy",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "UPDATED_BY",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "deleteTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "DELETE_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "deletedBy",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "DELETED_BY",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "jmxcontrol$ManagedBeanInfo",
+      "className": "ManagedBeanInfo",
+      "packageName": "com.haulmont.cuba.web.jmx.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.web.jmx.entity.ManagedBeanInfo",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "className",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "description",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "objectName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "domain",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "propertyList",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "jmxInstance",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.entity",
+            "className": "JmxInstance",
+            "fqn": "com.haulmont.cuba.core.entity.JmxInstance",
+            "label": "JmxInstance",
+            "entityName": "sys$JmxInstance"
+          },
+          "mappingType": "ASSOCIATION",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sec$SearchFolder",
+      "className": "SearchFolder",
+      "packageName": "com.haulmont.cuba.security.entity",
+      "table": "SEC_SEARCH_FOLDER",
+      "discriminator": "S",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": false,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.security.entity.SearchFolder",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "AbstractSearchFolder",
+      "attributes": [
+        {
+          "name": "user",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "User",
+            "fqn": "com.haulmont.cuba.security.entity.User",
+            "label": "User",
+            "entityName": "sec$User"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "USER_ID",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "presentation",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "Presentation",
+            "fqn": "com.haulmont.cuba.security.entity.Presentation",
+            "label": "Presentation",
+            "entityName": "sec$Presentation"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "PRESENTATION_ID",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "isSet",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "IS_SET",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "entityType",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ENTITY_TYPE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sec$FtsCondition",
+      "className": "FtsCondition",
+      "packageName": "com.haulmont.cuba.gui.components.filter.condition",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.gui.components.filter.condition.FtsCondition",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.gui.components.filter.condition",
+      "parentClassName": "AbstractCondition",
+      "attributes": []
+    },
+    {
+      "name": "sys$EntityClassPropertyDiff",
+      "className": "EntityClassPropertyDiff",
+      "packageName": "com.haulmont.cuba.core.entity.diff",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.diff.EntityClassPropertyDiff",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity.diff",
+      "parentClassName": "EntityPropertyDiff",
+      "attributes": []
+    },
+    {
+      "name": "sys$SendingAttachment",
+      "className": "SendingAttachment",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "table": "SYS_SENDING_ATTACHMENT",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.SendingAttachment",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "message",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.entity",
+            "className": "SendingMessage",
+            "fqn": "com.haulmont.cuba.core.entity.SendingMessage",
+            "label": "SendingMessage",
+            "entityName": "sys$SendingMessage"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "MESSAGE_ID",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "content",
+          "type": {
+            "packageName": "",
+            "className": "byte[]",
+            "fqn": "byte[]",
+            "label": "ByteArray"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CONTENT",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "contentFile",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.entity",
+            "className": "FileDescriptor",
+            "fqn": "com.haulmont.cuba.core.entity.FileDescriptor",
+            "label": "FileDescriptor",
+            "entityName": "sys$FileDescriptor"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "ONE_TO_ONE",
+          "readOnly": false,
+          "column": "CONTENT_FILE_ID",
+          "mandatory": false,
+          "unique": false,
+          "mappedBy": "",
+          "transient": false
+        },
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "500",
+          "transient": false
+        },
+        {
+          "name": "contentId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CONTENT_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "disposition",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "DISPOSITION",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "encoding",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "TEXT_ENCODING",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "sysTenantId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SYS_TENANT_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sec$LoggedEntity",
+      "className": "LoggedEntity",
+      "packageName": "com.haulmont.cuba.security.entity",
+      "table": "SEC_LOGGED_ENTITY",
+      "updatable": false,
+      "creatable": true,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.security.entity.LoggedEntity",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "createTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATE_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "createdBy",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATED_BY",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "100",
+          "transient": false
+        },
+        {
+          "name": "auto",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "AUTO",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "manual",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "MANUAL",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "attributes",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "LoggedAttribute",
+            "fqn": "com.haulmont.cuba.security.entity.LoggedAttribute",
+            "label": "LoggedAttribute",
+            "entityName": "sec$LoggedAttribute"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "ONE_TO_MANY",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "mappedBy": "entity",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sys$BaseUuidEntity",
+      "className": "BaseUuidEntity",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": true,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": false,
+      "mappedSuperclass": true,
+      "fqn": "com.haulmont.cuba.core.entity.BaseUuidEntity",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseGenericIdEntity",
+      "attributes": [
+        {
+          "name": "id",
+          "type": {
+            "packageName": "java.util",
+            "className": "UUID",
+            "fqn": "java.util.UUID",
+            "label": "UUID"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ID",
+          "mandatory": true,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sys$CategoryAttributeConfiguration",
+      "className": "CategoryAttributeConfiguration",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.CategoryAttributeConfiguration",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseGenericIdEntity",
+      "attributes": [
+        {
+          "name": "id",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "minInt",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "minDouble",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Double",
+            "fqn": "java.lang.Double",
+            "label": "Double"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "minDecimal",
+          "type": {
+            "packageName": "java.math",
+            "className": "BigDecimal",
+            "fqn": "java.math.BigDecimal",
+            "label": "BigDecimal"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "maxInt",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "maxDouble",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Double",
+            "fqn": "java.lang.Double",
+            "label": "Double"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "maxDecimal",
+          "type": {
+            "packageName": "java.math",
+            "className": "BigDecimal",
+            "fqn": "java.math.BigDecimal",
+            "label": "BigDecimal"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "validatorGroovyScript",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "columnName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "columnAlignment",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "columnWidth",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "numberFormatPattern",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "optionsLoaderType",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.entity",
+            "className": "CategoryAttributeOptionsLoaderType",
+            "fqn": "com.haulmont.cuba.core.entity.CategoryAttributeOptionsLoaderType",
+            "label": "CategoryAttributeOptionsLoaderType"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "optionsLoaderScript",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "recalculationScript",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "xCoordinate",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "yCoordinate",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "dependsOnAttributes",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.entity",
+            "className": "CategoryAttribute",
+            "fqn": "com.haulmont.cuba.core.entity.CategoryAttribute",
+            "label": "CategoryAttribute",
+            "entityName": "sys$CategoryAttribute"
+          },
+          "mappingType": "ASSOCIATION",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        }
+      ]
+    },
+    {
+      "name": "jmxcontrol$ManagedBeanOperation",
+      "className": "ManagedBeanOperation",
+      "packageName": "com.haulmont.cuba.web.jmx.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.web.jmx.entity.ManagedBeanOperation",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "returnType",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "description",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "runAsync",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "timeout",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Long",
+            "fqn": "java.lang.Long",
+            "label": "Long"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sec$LocalizedConstraintMessage",
+      "className": "LocalizedConstraintMessage",
+      "packageName": "com.haulmont.cuba.security.entity",
+      "table": "SEC_LOCALIZED_CONSTRAINT_MSG",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.security.entity.LocalizedConstraintMessage",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "entityName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ENTITY_NAME",
+          "mandatory": true,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "operationType",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "ConstraintOperationType",
+            "fqn": "com.haulmont.cuba.security.entity.ConstraintOperationType",
+            "label": "ConstraintOperationType"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "column": "OPERATION_TYPE",
+          "mandatory": true,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "values",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "VALUES_",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sys$ScheduledTask",
+      "className": "ScheduledTask",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "table": "SYS_SCHEDULED_TASK",
+      "updatable": true,
+      "creatable": true,
+      "hasUuid": false,
+      "softDelete": true,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "namePattern": "#name|beanName,methodName,className,scriptName",
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.ScheduledTask",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "createTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATE_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "createdBy",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATED_BY",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "updateTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "UPDATE_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "updatedBy",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "UPDATED_BY",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "deleteTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "DELETE_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "deletedBy",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "DELETED_BY",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "definedBy",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.entity",
+            "className": "ScheduledTaskDefinedBy",
+            "fqn": "com.haulmont.cuba.core.entity.ScheduledTaskDefinedBy",
+            "label": "ScheduledTaskDefinedBy"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "column": "DEFINED_BY",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "sysTenantId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SYS_TENANT_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "beanName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "BEAN_NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "methodName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "METHOD_NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "className",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CLASS_NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "scriptName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SCRIPT_NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "userName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "USER_NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "singleton",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "IS_SINGLETON",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "active",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "IS_ACTIVE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "period",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "PERIOD_",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "timeout",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "TIMEOUT",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "startDate",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "START_DATE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "cron",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CRON",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "schedulingType",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.entity",
+            "className": "SchedulingType",
+            "fqn": "com.haulmont.cuba.core.entity.SchedulingType",
+            "label": "SchedulingType"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "column": "SCHEDULING_TYPE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "timeFrame",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "TIME_FRAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "startDelay",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "START_DELAY",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "permittedServers",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "PERMITTED_SERVERS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "logStart",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "LOG_START",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "logFinish",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "LOG_FINISH",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "lastStartTime",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "LAST_START_TIME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "lastStartServer",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "LAST_START_SERVER",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "methodParamsXml",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "METHOD_PARAMS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "description",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "DESCRIPTION",
+          "mandatory": false,
+          "unique": false,
+          "length": "1000",
+          "transient": false
+        },
+        {
+          "name": "methodParametersString",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        }
+      ]
+    },
+    {
+      "name": "sys$CategoryAttributeEnumValue",
+      "className": "CategoryAttributeEnumValue",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.CategoryAttributeEnumValue",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "value",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "localizedValues",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sys$AbstractNotPersistentEntity",
+      "className": "AbstractNotPersistentEntity",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": true,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.AbstractNotPersistentEntity",
+      "imported": false,
+      "attributes": [
+        {
+          "name": "id",
+          "type": {
+            "packageName": "java.util",
+            "className": "UUID",
+            "fqn": "java.util.UUID",
+            "label": "UUID"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        }
+      ]
+    },
+    {
+      "name": "jmxcontrol$ManagedBeanAttribute",
+      "className": "ManagedBeanAttribute",
+      "packageName": "com.haulmont.cuba.web.jmx.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.web.jmx.entity.ManagedBeanAttribute",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "description",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "type",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "readableWriteable",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "readable",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "writeable",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "valueString",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        }
+      ]
+    },
+    {
+      "name": "sys$LockInfo",
+      "className": "LockInfo",
+      "packageName": "com.haulmont.cuba.core.global",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.global.LockInfo",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "entityId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        },
+        {
+          "name": "entityName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        },
+        {
+          "name": "since",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        },
+        {
+          "name": "user",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "User",
+            "fqn": "com.haulmont.cuba.security.entity.User",
+            "label": "User",
+            "entityName": "sec$User"
+          },
+          "mappingType": "ASSOCIATION",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        }
+      ]
+    },
+    {
+      "name": "sys$BaseIntIdentityIdEntity",
+      "className": "BaseIntIdentityIdEntity",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": false,
+      "mappedSuperclass": true,
+      "fqn": "com.haulmont.cuba.core.entity.BaseIntIdentityIdEntity",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseDbGeneratedIdEntity",
+      "attributes": [
+        {
+          "name": "id",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ID",
+          "mandatory": true,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sys$AttributeLocaleData",
+      "className": "AttributeLocaleData",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "namePattern": "%s %s|name,languageWithCode",
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.AttributeLocaleData",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "description",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "locale",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "language",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "languageWithCode",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        }
+      ]
+    },
+    {
+      "name": "sec$UserSessionEntity",
+      "className": "UserSessionEntity",
+      "packageName": "com.haulmont.cuba.security.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.security.entity.UserSessionEntity",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "login",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "userName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "address",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "clientInfo",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "since",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "lastUsedTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "system",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Boolean",
+            "fqn": "java.lang.Boolean",
+            "label": "Boolean"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "sysTenantId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sec$Permission",
+      "className": "Permission",
+      "packageName": "com.haulmont.cuba.security.entity",
+      "table": "SEC_PERMISSION",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.security.entity.Permission",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "type",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "PermissionType",
+            "fqn": "com.haulmont.cuba.security.entity.PermissionType",
+            "label": "PermissionType"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "column": "PERMISSION_TYPE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "target",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "TARGET",
+          "mandatory": false,
+          "unique": false,
+          "length": "100",
+          "transient": false
+        },
+        {
+          "name": "value",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "VALUE_",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "role",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "Role",
+            "fqn": "com.haulmont.cuba.security.entity.Role",
+            "label": "Role",
+            "entityName": "sec$Role"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "ROLE_ID",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sec$MultipleTarget",
+      "className": "MultiplePermissionTarget",
+      "packageName": "com.haulmont.cuba.gui.app.security.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.gui.app.security.entity.MultiplePermissionTarget",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.gui.app.security.entity",
+      "parentClassName": "AbstractPermissionTarget",
+      "attributes": [
+        {
+          "name": "permissions",
+          "type": {
+            "packageName": "com.haulmont.cuba.gui.app.security.entity",
+            "className": "AttributeTarget",
+            "fqn": "com.haulmont.cuba.gui.app.security.entity.AttributeTarget",
+            "label": "AttributeTarget",
+            "entityName": "sec$AttributeTarget"
+          },
+          "mappingType": "ASSOCIATION",
+          "readOnly": true,
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "localName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "entityMetaClassName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "permissionsInfo",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        }
+      ]
+    },
+    {
+      "name": "sec$CustomConditionDescriptor",
+      "className": "CustomConditionDescriptor",
+      "packageName": "com.haulmont.cuba.gui.components.filter.descriptor",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.gui.components.filter.descriptor.CustomConditionDescriptor",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.gui.components.filter.descriptor",
+      "parentClassName": "AbstractConditionDescriptor",
+      "attributes": []
+    },
+    {
+      "name": "sec$Target",
+      "className": "BasicPermissionTarget",
+      "packageName": "com.haulmont.cuba.gui.app.security.entity",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.gui.app.security.entity.BasicPermissionTarget",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.gui.app.security.entity",
+      "parentClassName": "AbstractPermissionTarget",
+      "attributes": [
+        {
+          "name": "permissionVariant",
+          "type": {
+            "packageName": "com.haulmont.cuba.gui.app.security.entity",
+            "className": "PermissionVariant",
+            "fqn": "com.haulmont.cuba.gui.app.security.entity.PermissionVariant",
+            "label": "PermissionVariant"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sys$QueryResult",
+      "className": "QueryResult",
+      "packageName": "com.haulmont.cuba.core.entity",
+      "table": "SYS_QUERY_RESULT",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.core.entity.QueryResult",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseIdentityIdEntity",
+      "attributes": [
+        {
+          "name": "sessionId",
+          "type": {
+            "packageName": "java.util",
+            "className": "UUID",
+            "fqn": "java.util.UUID",
+            "label": "UUID"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SESSION_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "queryKey",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "QUERY_KEY",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "entityId",
+          "type": {
+            "packageName": "java.util",
+            "className": "UUID",
+            "fqn": "java.util.UUID",
+            "label": "UUID"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ENTITY_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "stringEntityId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "STRING_ENTITY_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "intEntityId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Integer",
+            "fqn": "java.lang.Integer",
+            "label": "Integer"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "INT_ENTITY_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "longEntityId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "Long",
+            "fqn": "java.lang.Long",
+            "label": "Long"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "LONG_ENTITY_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sec$DynamicAttributesConditionCreator",
+      "className": "DynamicAttributesConditionCreator",
+      "packageName": "com.haulmont.cuba.gui.components.filter.descriptor",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.gui.components.filter.descriptor.DynamicAttributesConditionCreator",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.gui.components.filter.descriptor",
+      "parentClassName": "AbstractConditionDescriptor",
+      "attributes": []
+    },
+    {
+      "name": "sec$DynamicAttributesCondition",
+      "className": "DynamicAttributesCondition",
+      "packageName": "com.haulmont.cuba.gui.components.filter.condition",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": false,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.gui.components.filter.condition.DynamicAttributesCondition",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.gui.components.filter.condition",
+      "parentClassName": "AbstractCondition",
+      "attributes": []
+    },
+    {
+      "name": "sec$UserSubstitution",
+      "className": "UserSubstitution",
+      "packageName": "com.haulmont.cuba.security.entity",
+      "table": "SEC_USER_SUBSTITUTION",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.security.entity.UserSubstitution",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "user",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "User",
+            "fqn": "com.haulmont.cuba.security.entity.User",
+            "label": "User",
+            "entityName": "sec$User"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "USER_ID",
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "substitutedUser",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "User",
+            "fqn": "com.haulmont.cuba.security.entity.User",
+            "label": "User",
+            "entityName": "sec$User"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "SUBSTITUTED_USER_ID",
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "startDate",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "START_DATE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false,
+          "temporalType": "DATE"
+        },
+        {
+          "name": "endDate",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "END_DATE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false,
+          "temporalType": "DATE"
+        },
+        {
+          "name": "sysTenantId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SYS_TENANT_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sec$SessionLogEntry",
+      "className": "SessionLogEntry",
+      "packageName": "com.haulmont.cuba.security.entity",
+      "table": "SEC_SESSION_LOG",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": false,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.security.entity.SessionLogEntry",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "sessionId",
+          "type": {
+            "packageName": "java.util",
+            "className": "UUID",
+            "fqn": "java.util.UUID",
+            "label": "UUID"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SESSION_ID",
+          "mandatory": true,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "substitutedUser",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "User",
+            "fqn": "com.haulmont.cuba.security.entity.User",
+            "label": "User",
+            "entityName": "sec$User"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "SUBSTITUTED_USER_ID",
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "user",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "User",
+            "fqn": "com.haulmont.cuba.security.entity.User",
+            "label": "User",
+            "entityName": "sec$User"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "USER_ID",
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "userData",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "USER_DATA",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "lastAction",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "SessionAction",
+            "fqn": "com.haulmont.cuba.security.entity.SessionAction",
+            "label": "SessionAction"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "column": "LAST_ACTION",
+          "mandatory": true,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "clientInfo",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CLIENT_INFO",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "address",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ADDRESS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "startedTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "DateTime"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "STARTED_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false,
+          "temporalType": "TIMESTAMP"
+        },
+        {
+          "name": "finishedTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "DateTime"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "FINISHED_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false,
+          "temporalType": "TIMESTAMP"
+        },
+        {
+          "name": "clientType",
+          "type": {
+            "packageName": "com.haulmont.cuba.core.global",
+            "className": "ClientType",
+            "fqn": "com.haulmont.cuba.core.global.ClientType",
+            "label": "ClientType"
+          },
+          "mappingType": "ENUM",
+          "readOnly": false,
+          "column": "CLIENT_TYPE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "server",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SERVER_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "sysTenantId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SYS_TENANT_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sec$UserRole",
+      "className": "UserRole",
+      "packageName": "com.haulmont.cuba.security.entity",
+      "table": "SEC_USER_ROLE",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.security.entity.UserRole",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "user",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "User",
+            "fqn": "com.haulmont.cuba.security.entity.User",
+            "label": "User",
+            "entityName": "sec$User"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "USER_ID",
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "role",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "Role",
+            "fqn": "com.haulmont.cuba.security.entity.Role",
+            "label": "Role",
+            "entityName": "sec$Role"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "ROLE_ID",
+          "mandatory": true,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "roleName",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "ROLE_NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sec$SessionAttribute",
+      "className": "SessionAttribute",
+      "packageName": "com.haulmont.cuba.security.entity",
+      "table": "SEC_SESSION_ATTR",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.cuba.security.entity.SessionAttribute",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "StandardEntity",
+      "attributes": [
+        {
+          "name": "name",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "NAME",
+          "mandatory": false,
+          "unique": false,
+          "length": "50",
+          "transient": false
+        },
+        {
+          "name": "stringValue",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "STR_VALUE",
+          "mandatory": false,
+          "unique": false,
+          "length": "1000",
+          "transient": false
+        },
+        {
+          "name": "datatype",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "DATATYPE",
+          "mandatory": false,
+          "unique": false,
+          "length": "20",
+          "transient": false
+        },
+        {
+          "name": "group",
+          "type": {
+            "packageName": "com.haulmont.cuba.security.entity",
+            "className": "Group",
+            "fqn": "com.haulmont.cuba.security.entity.Group",
+            "label": "Group",
+            "entityName": "sec$Group"
+          },
+          "mappingType": "ASSOCIATION",
+          "cardinality": "MANY_TO_ONE",
+          "readOnly": false,
+          "column": "GROUP_ID",
+          "mandatory": false,
+          "unique": false,
+          "transient": false
+        },
+        {
+          "name": "sysTenantId",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "SYS_TENANT_ID",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "datatypeCaption",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": true,
+          "mandatory": false,
+          "unique": false,
+          "transient": true
+        }
+      ]
+    },
+    {
+      "name": "sys$RefreshToken",
+      "className": "RefreshToken",
+      "packageName": "com.haulmont.addon.restapi.entity",
+      "table": "SYS_REFRESH_TOKEN",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.addon.restapi.entity.RefreshToken",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "createTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATE_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "tokenValue",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "TOKEN_VALUE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "tokenBytes",
+          "type": {
+            "packageName": "",
+            "className": "byte[]",
+            "fqn": "byte[]",
+            "label": "ByteArray"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "TOKEN_BYTES",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "authenticationBytes",
+          "type": {
+            "packageName": "",
+            "className": "byte[]",
+            "fqn": "byte[]",
+            "label": "ByteArray"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "AUTHENTICATION_BYTES",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "expiry",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "EXPIRY",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "userLogin",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "USER_LOGIN",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    },
+    {
+      "name": "sys$AccessToken",
+      "className": "AccessToken",
+      "packageName": "com.haulmont.addon.restapi.entity",
+      "table": "SYS_ACCESS_TOKEN",
+      "updatable": false,
+      "creatable": false,
+      "hasUuid": false,
+      "softDelete": false,
+      "versioned": false,
+      "embeddable": false,
+      "persistentEntity": true,
+      "replaceParent": false,
+      "systemLevel": true,
+      "mappedSuperclass": false,
+      "fqn": "com.haulmont.addon.restapi.entity.AccessToken",
+      "imported": false,
+      "parentPackage": "com.haulmont.cuba.core.entity",
+      "parentClassName": "BaseUuidEntity",
+      "attributes": [
+        {
+          "name": "createTs",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "CREATE_TS",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "tokenValue",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "TOKEN_VALUE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "tokenBytes",
+          "type": {
+            "packageName": "",
+            "className": "byte[]",
+            "fqn": "byte[]",
+            "label": "ByteArray"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "TOKEN_BYTES",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "authenticationKey",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "AUTHENTICATION_KEY",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "authenticationBytes",
+          "type": {
+            "packageName": "",
+            "className": "byte[]",
+            "fqn": "byte[]",
+            "label": "ByteArray"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "AUTHENTICATION_BYTES",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "expiry",
+          "type": {
+            "packageName": "java.util",
+            "className": "Date",
+            "fqn": "java.util.Date",
+            "label": "Date"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "EXPIRY",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "userLogin",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "USER_LOGIN",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "locale",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "LOCALE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        },
+        {
+          "name": "refreshTokenValue",
+          "type": {
+            "packageName": "java.lang",
+            "className": "String",
+            "fqn": "java.lang.String",
+            "label": "String"
+          },
+          "mappingType": "DATATYPE",
+          "readOnly": false,
+          "column": "REFRESH_TOKEN_VALUE",
+          "mandatory": false,
+          "unique": false,
+          "length": "255",
+          "transient": false
+        }
+      ]
+    }
+  ],
+  "views": [
+    {
+      "name": "_minimal",
+      "entity": "ScrUserInfo",
+      "classFqn": "com.company.scr.entity.ScrUserInfo",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "ScrUserInfo",
+      "classFqn": "com.company.scr.entity.ScrUserInfo",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "ScrUserInfo",
+      "classFqn": "com.company.scr.entity.ScrUserInfo",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "scr_AssociationO2MTestEntity",
+      "classFqn": "com.company.scr.entity.test.AssociationO2MTestEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_local",
+      "entity": "scr_AssociationO2MTestEntity",
+      "classFqn": "com.company.scr.entity.test.AssociationO2MTestEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "scr_AssociationO2MTestEntity",
+      "classFqn": "com.company.scr.entity.test.AssociationO2MTestEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "associationO2MTestEntity-view",
+      "entity": "scr_AssociationO2MTestEntity",
+      "classFqn": "com.company.scr.entity.test.AssociationO2MTestEntity",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "datatypesTestEntity",
+          "entity": "scr_DatatypesTestEntity",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "datatypesTestEntity",
+          "entity": "scr_DatatypesTestEntity",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "scr_AssociationM2MTestEntity",
+      "classFqn": "com.company.scr.entity.test.AssociationM2MTestEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_local",
+      "entity": "scr_AssociationM2MTestEntity",
+      "classFqn": "com.company.scr.entity.test.AssociationM2MTestEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "scr_AssociationM2MTestEntity",
+      "classFqn": "com.company.scr.entity.test.AssociationM2MTestEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "associationM2MTestEntity-view",
+      "entity": "scr_AssociationM2MTestEntity",
+      "classFqn": "com.company.scr.entity.test.AssociationM2MTestEntity",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "datatypesTestEntities",
+          "entity": "scr_DatatypesTestEntity",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "datatypesTestEntities",
+          "entity": "scr_DatatypesTestEntity",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "scr_AssociationM2OTestEntity",
+      "classFqn": "com.company.scr.entity.test.AssociationM2OTestEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_local",
+      "entity": "scr_AssociationM2OTestEntity",
+      "classFqn": "com.company.scr.entity.test.AssociationM2OTestEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "scr_AssociationM2OTestEntity",
+      "classFqn": "com.company.scr.entity.test.AssociationM2OTestEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "associationM2OTestEntity-view",
+      "entity": "scr_AssociationM2OTestEntity",
+      "classFqn": "com.company.scr.entity.test.AssociationM2OTestEntity",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "scr_CompositionO2MTestEntity",
+      "classFqn": "com.company.scr.entity.test.CompositionO2MTestEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_local",
+      "entity": "scr_CompositionO2MTestEntity",
+      "classFqn": "com.company.scr.entity.test.CompositionO2MTestEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "scr_CompositionO2MTestEntity",
+      "classFqn": "com.company.scr.entity.test.CompositionO2MTestEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "compositionO2MTestEntity-view",
+      "entity": "scr_CompositionO2MTestEntity",
+      "classFqn": "com.company.scr.entity.test.CompositionO2MTestEntity",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "datatypesTestEntity",
+          "entity": "scr_DatatypesTestEntity",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "datatypesTestEntity",
+          "entity": "scr_DatatypesTestEntity",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "scr$TechnicalCertificate",
+      "classFqn": "com.company.scr.entity.TechnicalCertificate",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "certNumber",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "certNumber",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_local",
+      "entity": "scr$TechnicalCertificate",
+      "classFqn": "com.company.scr.entity.TechnicalCertificate",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "certNumber",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "certNumber",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "scr$TechnicalCertificate",
+      "classFqn": "com.company.scr.entity.TechnicalCertificate",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "certNumber",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "certNumber",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "scr_DatatypesTestEntity",
+      "classFqn": "com.company.scr.entity.test.DatatypesTestEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_local",
+      "entity": "scr_DatatypesTestEntity",
+      "classFqn": "com.company.scr.entity.test.DatatypesTestEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "bigDecimalAttr",
+          "lazy": false
+        },
+        {
+          "name": "booleanAttr",
+          "lazy": false
+        },
+        {
+          "name": "byteArrayAttr",
+          "lazy": false
+        },
+        {
+          "name": "dateAttr",
+          "lazy": false
+        },
+        {
+          "name": "dateTimeAttr",
+          "lazy": false
+        },
+        {
+          "name": "doubleAttr",
+          "lazy": false
+        },
+        {
+          "name": "integerAttr",
+          "lazy": false
+        },
+        {
+          "name": "longAttr",
+          "lazy": false
+        },
+        {
+          "name": "stringAttr",
+          "lazy": false
+        },
+        {
+          "name": "timeAttr",
+          "lazy": false
+        },
+        {
+          "name": "uuidAttr",
+          "lazy": false
+        },
+        {
+          "name": "localDateTimeAttr",
+          "lazy": false
+        },
+        {
+          "name": "offsetDateTimeAttr",
+          "lazy": false
+        },
+        {
+          "name": "localDateAttr",
+          "lazy": false
+        },
+        {
+          "name": "localTimeAttr",
+          "lazy": false
+        },
+        {
+          "name": "offsetTimeAttr",
+          "lazy": false
+        },
+        {
+          "name": "enumAttr",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "bigDecimalAttr",
+          "lazy": false
+        },
+        {
+          "name": "booleanAttr",
+          "lazy": false
+        },
+        {
+          "name": "byteArrayAttr",
+          "lazy": false
+        },
+        {
+          "name": "dateAttr",
+          "lazy": false
+        },
+        {
+          "name": "dateTimeAttr",
+          "lazy": false
+        },
+        {
+          "name": "doubleAttr",
+          "lazy": false
+        },
+        {
+          "name": "integerAttr",
+          "lazy": false
+        },
+        {
+          "name": "longAttr",
+          "lazy": false
+        },
+        {
+          "name": "stringAttr",
+          "lazy": false
+        },
+        {
+          "name": "timeAttr",
+          "lazy": false
+        },
+        {
+          "name": "uuidAttr",
+          "lazy": false
+        },
+        {
+          "name": "localDateTimeAttr",
+          "lazy": false
+        },
+        {
+          "name": "offsetDateTimeAttr",
+          "lazy": false
+        },
+        {
+          "name": "localDateAttr",
+          "lazy": false
+        },
+        {
+          "name": "localTimeAttr",
+          "lazy": false
+        },
+        {
+          "name": "offsetTimeAttr",
+          "lazy": false
+        },
+        {
+          "name": "enumAttr",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "scr_DatatypesTestEntity",
+      "classFqn": "com.company.scr.entity.test.DatatypesTestEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "bigDecimalAttr",
+          "lazy": false
+        },
+        {
+          "name": "booleanAttr",
+          "lazy": false
+        },
+        {
+          "name": "byteArrayAttr",
+          "lazy": false
+        },
+        {
+          "name": "dateAttr",
+          "lazy": false
+        },
+        {
+          "name": "dateTimeAttr",
+          "lazy": false
+        },
+        {
+          "name": "doubleAttr",
+          "lazy": false
+        },
+        {
+          "name": "integerAttr",
+          "lazy": false
+        },
+        {
+          "name": "longAttr",
+          "lazy": false
+        },
+        {
+          "name": "stringAttr",
+          "lazy": false
+        },
+        {
+          "name": "timeAttr",
+          "lazy": false
+        },
+        {
+          "name": "uuidAttr",
+          "lazy": false
+        },
+        {
+          "name": "localDateTimeAttr",
+          "lazy": false
+        },
+        {
+          "name": "offsetDateTimeAttr",
+          "lazy": false
+        },
+        {
+          "name": "localDateAttr",
+          "lazy": false
+        },
+        {
+          "name": "localTimeAttr",
+          "lazy": false
+        },
+        {
+          "name": "offsetTimeAttr",
+          "lazy": false
+        },
+        {
+          "name": "enumAttr",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "bigDecimalAttr",
+          "lazy": false
+        },
+        {
+          "name": "booleanAttr",
+          "lazy": false
+        },
+        {
+          "name": "byteArrayAttr",
+          "lazy": false
+        },
+        {
+          "name": "dateAttr",
+          "lazy": false
+        },
+        {
+          "name": "dateTimeAttr",
+          "lazy": false
+        },
+        {
+          "name": "doubleAttr",
+          "lazy": false
+        },
+        {
+          "name": "integerAttr",
+          "lazy": false
+        },
+        {
+          "name": "longAttr",
+          "lazy": false
+        },
+        {
+          "name": "stringAttr",
+          "lazy": false
+        },
+        {
+          "name": "timeAttr",
+          "lazy": false
+        },
+        {
+          "name": "uuidAttr",
+          "lazy": false
+        },
+        {
+          "name": "localDateTimeAttr",
+          "lazy": false
+        },
+        {
+          "name": "offsetDateTimeAttr",
+          "lazy": false
+        },
+        {
+          "name": "localDateAttr",
+          "lazy": false
+        },
+        {
+          "name": "localTimeAttr",
+          "lazy": false
+        },
+        {
+          "name": "offsetTimeAttr",
+          "lazy": false
+        },
+        {
+          "name": "enumAttr",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "datatypesTestEntity-view",
+      "entity": "scr_DatatypesTestEntity",
+      "classFqn": "com.company.scr.entity.test.DatatypesTestEntity",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "associationO2Oattr",
+          "entity": "scr_AssociationO2OTestEntity",
+          "lazy": false
+        },
+        {
+          "name": "associationO2Mattr",
+          "entity": "scr_AssociationO2MTestEntity",
+          "lazy": false
+        },
+        {
+          "name": "associationM2Oattr",
+          "entity": "scr_AssociationM2OTestEntity",
+          "lazy": false
+        },
+        {
+          "name": "associationM2Mattr",
+          "entity": "scr_AssociationM2MTestEntity",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "bigDecimalAttr",
+          "lazy": false
+        },
+        {
+          "name": "booleanAttr",
+          "lazy": false
+        },
+        {
+          "name": "byteArrayAttr",
+          "lazy": false
+        },
+        {
+          "name": "dateAttr",
+          "lazy": false
+        },
+        {
+          "name": "dateTimeAttr",
+          "lazy": false
+        },
+        {
+          "name": "doubleAttr",
+          "lazy": false
+        },
+        {
+          "name": "integerAttr",
+          "lazy": false
+        },
+        {
+          "name": "longAttr",
+          "lazy": false
+        },
+        {
+          "name": "stringAttr",
+          "lazy": false
+        },
+        {
+          "name": "timeAttr",
+          "lazy": false
+        },
+        {
+          "name": "uuidAttr",
+          "lazy": false
+        },
+        {
+          "name": "localDateTimeAttr",
+          "lazy": false
+        },
+        {
+          "name": "offsetDateTimeAttr",
+          "lazy": false
+        },
+        {
+          "name": "localDateAttr",
+          "lazy": false
+        },
+        {
+          "name": "localTimeAttr",
+          "lazy": false
+        },
+        {
+          "name": "offsetTimeAttr",
+          "lazy": false
+        },
+        {
+          "name": "enumAttr",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "associationO2Oattr",
+          "entity": "scr_AssociationO2OTestEntity",
+          "lazy": false
+        },
+        {
+          "name": "associationO2Mattr",
+          "entity": "scr_AssociationO2MTestEntity",
+          "lazy": false
+        },
+        {
+          "name": "associationM2Oattr",
+          "entity": "scr_AssociationM2OTestEntity",
+          "lazy": false
+        },
+        {
+          "name": "associationM2Mattr",
+          "entity": "scr_AssociationM2MTestEntity",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "scr$FavoriteCar",
+      "classFqn": "com.company.scr.entity.FavoriteCar",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "car",
+          "entity": "scr$Car",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "car",
+          "entity": "scr$Car",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_local",
+      "entity": "scr$FavoriteCar",
+      "classFqn": "com.company.scr.entity.FavoriteCar",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "notes",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "notes",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "scr$FavoriteCar",
+      "classFqn": "com.company.scr.entity.FavoriteCar",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "car",
+          "entity": "scr$Car",
+          "lazy": false
+        },
+        {
+          "name": "notes",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "car",
+          "entity": "scr$Car",
+          "lazy": false
+        },
+        {
+          "name": "notes",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "favoriteCar-view",
+      "entity": "scr$FavoriteCar",
+      "classFqn": "com.company.scr.entity.FavoriteCar",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "car",
+          "entity": "scr$Car",
+          "lazy": false
+        },
+        {
+          "name": "user",
+          "entity": "sec$User",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "notes",
+          "lazy": false
+        },
+        {
+          "name": "car",
+          "entity": "scr$Car",
+          "lazy": false
+        },
+        {
+          "name": "user",
+          "entity": "sec$User",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "favoriteCar-edit",
+      "entity": "scr$FavoriteCar",
+      "classFqn": "com.company.scr.entity.FavoriteCar",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "car",
+          "entity": "scr$Car",
+          "lazy": false
+        },
+        {
+          "name": "user",
+          "entity": "sec$User",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "notes",
+          "lazy": false
+        },
+        {
+          "name": "car",
+          "entity": "scr$Car",
+          "lazy": false
+        },
+        {
+          "name": "user",
+          "entity": "sec$User",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "scr$Garage",
+      "classFqn": "com.company.scr.entity.Garage",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_local",
+      "entity": "scr$Garage",
+      "classFqn": "com.company.scr.entity.Garage",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "capacity",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "capacity",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "scr$Garage",
+      "classFqn": "com.company.scr.entity.Garage",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "capacity",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "capacity",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "scr$Car",
+      "classFqn": "com.company.scr.entity.Car",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "manufacturer",
+          "lazy": false
+        },
+        {
+          "name": "model",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "manufacturer",
+          "lazy": false
+        },
+        {
+          "name": "model",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_local",
+      "entity": "scr$Car",
+      "classFqn": "com.company.scr.entity.Car",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "manufacturer",
+          "lazy": false
+        },
+        {
+          "name": "model",
+          "lazy": false
+        },
+        {
+          "name": "regNumber",
+          "lazy": false
+        },
+        {
+          "name": "purchaseDate",
+          "lazy": false
+        },
+        {
+          "name": "manufactureDate",
+          "lazy": false
+        },
+        {
+          "name": "wheelOnRight",
+          "lazy": false
+        },
+        {
+          "name": "carType",
+          "lazy": false
+        },
+        {
+          "name": "ecoRank",
+          "lazy": false
+        },
+        {
+          "name": "maxPassengers",
+          "lazy": false
+        },
+        {
+          "name": "price",
+          "lazy": false
+        },
+        {
+          "name": "mileage",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "manufacturer",
+          "lazy": false
+        },
+        {
+          "name": "model",
+          "lazy": false
+        },
+        {
+          "name": "regNumber",
+          "lazy": false
+        },
+        {
+          "name": "purchaseDate",
+          "lazy": false
+        },
+        {
+          "name": "manufactureDate",
+          "lazy": false
+        },
+        {
+          "name": "wheelOnRight",
+          "lazy": false
+        },
+        {
+          "name": "carType",
+          "lazy": false
+        },
+        {
+          "name": "ecoRank",
+          "lazy": false
+        },
+        {
+          "name": "maxPassengers",
+          "lazy": false
+        },
+        {
+          "name": "price",
+          "lazy": false
+        },
+        {
+          "name": "mileage",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "scr$Car",
+      "classFqn": "com.company.scr.entity.Car",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "manufacturer",
+          "lazy": false
+        },
+        {
+          "name": "model",
+          "lazy": false
+        },
+        {
+          "name": "regNumber",
+          "lazy": false
+        },
+        {
+          "name": "purchaseDate",
+          "lazy": false
+        },
+        {
+          "name": "manufactureDate",
+          "lazy": false
+        },
+        {
+          "name": "wheelOnRight",
+          "lazy": false
+        },
+        {
+          "name": "carType",
+          "lazy": false
+        },
+        {
+          "name": "ecoRank",
+          "lazy": false
+        },
+        {
+          "name": "maxPassengers",
+          "lazy": false
+        },
+        {
+          "name": "price",
+          "lazy": false
+        },
+        {
+          "name": "mileage",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "manufacturer",
+          "lazy": false
+        },
+        {
+          "name": "model",
+          "lazy": false
+        },
+        {
+          "name": "regNumber",
+          "lazy": false
+        },
+        {
+          "name": "purchaseDate",
+          "lazy": false
+        },
+        {
+          "name": "manufactureDate",
+          "lazy": false
+        },
+        {
+          "name": "wheelOnRight",
+          "lazy": false
+        },
+        {
+          "name": "carType",
+          "lazy": false
+        },
+        {
+          "name": "ecoRank",
+          "lazy": false
+        },
+        {
+          "name": "maxPassengers",
+          "lazy": false
+        },
+        {
+          "name": "price",
+          "lazy": false
+        },
+        {
+          "name": "mileage",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "car-edit",
+      "entity": "scr$Car",
+      "classFqn": "com.company.scr.entity.Car",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "garage",
+          "entity": "scr$Garage",
+          "lazy": false
+        },
+        {
+          "name": "technicalCertificate",
+          "entity": "scr$TechnicalCertificate",
+          "lazy": false
+        },
+        {
+          "name": "photo",
+          "entity": "sys$FileDescriptor",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "manufacturer",
+          "lazy": false
+        },
+        {
+          "name": "model",
+          "lazy": false
+        },
+        {
+          "name": "regNumber",
+          "lazy": false
+        },
+        {
+          "name": "purchaseDate",
+          "lazy": false
+        },
+        {
+          "name": "manufactureDate",
+          "lazy": false
+        },
+        {
+          "name": "wheelOnRight",
+          "lazy": false
+        },
+        {
+          "name": "carType",
+          "lazy": false
+        },
+        {
+          "name": "ecoRank",
+          "lazy": false
+        },
+        {
+          "name": "maxPassengers",
+          "lazy": false
+        },
+        {
+          "name": "price",
+          "lazy": false
+        },
+        {
+          "name": "mileage",
+          "lazy": false
+        },
+        {
+          "name": "garage",
+          "entity": "scr$Garage",
+          "lazy": false
+        },
+        {
+          "name": "technicalCertificate",
+          "entity": "scr$TechnicalCertificate",
+          "lazy": false
+        },
+        {
+          "name": "photo",
+          "entity": "sys$FileDescriptor",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "scr_CompositionO2OTestEntity",
+      "classFqn": "com.company.scr.entity.test.CompositionO2OTestEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_local",
+      "entity": "scr_CompositionO2OTestEntity",
+      "classFqn": "com.company.scr.entity.test.CompositionO2OTestEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "scr_CompositionO2OTestEntity",
+      "classFqn": "com.company.scr.entity.test.CompositionO2OTestEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "compositionO2OTestEntity-view",
+      "entity": "scr_CompositionO2OTestEntity",
+      "classFqn": "com.company.scr.entity.test.CompositionO2OTestEntity",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "scr$CarRent",
+      "classFqn": "com.company.scr.entity.CarRent",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "scr$CarRent",
+      "classFqn": "com.company.scr.entity.CarRent",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "fromDate",
+          "lazy": false
+        },
+        {
+          "name": "fromTime",
+          "lazy": false
+        },
+        {
+          "name": "fromDateTime",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "fromDate",
+          "lazy": false
+        },
+        {
+          "name": "fromTime",
+          "lazy": false
+        },
+        {
+          "name": "fromDateTime",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "scr$CarRent",
+      "classFqn": "com.company.scr.entity.CarRent",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "fromDate",
+          "lazy": false
+        },
+        {
+          "name": "fromTime",
+          "lazy": false
+        },
+        {
+          "name": "fromDateTime",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "fromDate",
+          "lazy": false
+        },
+        {
+          "name": "fromTime",
+          "lazy": false
+        },
+        {
+          "name": "fromDateTime",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "carRent-edit",
+      "entity": "scr$CarRent",
+      "classFqn": "com.company.scr.entity.CarRent",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "car",
+          "entity": "scr$Car",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "fromDate",
+          "lazy": false
+        },
+        {
+          "name": "fromTime",
+          "lazy": false
+        },
+        {
+          "name": "fromDateTime",
+          "lazy": false
+        },
+        {
+          "name": "car",
+          "entity": "scr$Car",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "scr_AssociationO2OTestEntity",
+      "classFqn": "com.company.scr.entity.test.AssociationO2OTestEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_local",
+      "entity": "scr_AssociationO2OTestEntity",
+      "classFqn": "com.company.scr.entity.test.AssociationO2OTestEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "scr_AssociationO2OTestEntity",
+      "classFqn": "com.company.scr.entity.test.AssociationO2OTestEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "associationO2OTestEntity-view",
+      "entity": "scr_AssociationO2OTestEntity",
+      "classFqn": "com.company.scr.entity.test.AssociationO2OTestEntity",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "datatypesTestEntity",
+          "entity": "scr_DatatypesTestEntity",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "datatypesTestEntity",
+          "entity": "scr_DatatypesTestEntity",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "scr$SparePart",
+      "classFqn": "com.company.scr.entity.SparePart",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_local",
+      "entity": "scr$SparePart",
+      "classFqn": "com.company.scr.entity.SparePart",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "scr$SparePart",
+      "classFqn": "com.company.scr.entity.SparePart",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "sparePart-view",
+      "entity": "scr$SparePart",
+      "classFqn": "com.company.scr.entity.SparePart",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "spareParts",
+          "entity": "scr$SparePart",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "spareParts",
+          "entity": "scr$SparePart",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "scr$User",
+      "classFqn": "com.company.scr.entity.ScrUser",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "login",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "login",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_local",
+      "entity": "scr$User",
+      "classFqn": "com.company.scr.entity.ScrUser",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "phone",
+          "lazy": false
+        },
+        {
+          "name": "login",
+          "lazy": false
+        },
+        {
+          "name": "loginLowerCase",
+          "lazy": false
+        },
+        {
+          "name": "password",
+          "lazy": false
+        },
+        {
+          "name": "passwordEncryption",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "firstName",
+          "lazy": false
+        },
+        {
+          "name": "lastName",
+          "lazy": false
+        },
+        {
+          "name": "middleName",
+          "lazy": false
+        },
+        {
+          "name": "position",
+          "lazy": false
+        },
+        {
+          "name": "email",
+          "lazy": false
+        },
+        {
+          "name": "language",
+          "lazy": false
+        },
+        {
+          "name": "timeZone",
+          "lazy": false
+        },
+        {
+          "name": "timeZoneAuto",
+          "lazy": false
+        },
+        {
+          "name": "active",
+          "lazy": false
+        },
+        {
+          "name": "changePasswordAtNextLogon",
+          "lazy": false
+        },
+        {
+          "name": "groupNames",
+          "lazy": false
+        },
+        {
+          "name": "ipMask",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "phone",
+          "lazy": false
+        },
+        {
+          "name": "login",
+          "lazy": false
+        },
+        {
+          "name": "loginLowerCase",
+          "lazy": false
+        },
+        {
+          "name": "password",
+          "lazy": false
+        },
+        {
+          "name": "passwordEncryption",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "firstName",
+          "lazy": false
+        },
+        {
+          "name": "lastName",
+          "lazy": false
+        },
+        {
+          "name": "middleName",
+          "lazy": false
+        },
+        {
+          "name": "position",
+          "lazy": false
+        },
+        {
+          "name": "email",
+          "lazy": false
+        },
+        {
+          "name": "language",
+          "lazy": false
+        },
+        {
+          "name": "timeZone",
+          "lazy": false
+        },
+        {
+          "name": "timeZoneAuto",
+          "lazy": false
+        },
+        {
+          "name": "active",
+          "lazy": false
+        },
+        {
+          "name": "changePasswordAtNextLogon",
+          "lazy": false
+        },
+        {
+          "name": "groupNames",
+          "lazy": false
+        },
+        {
+          "name": "ipMask",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "scr$User",
+      "classFqn": "com.company.scr.entity.ScrUser",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "login",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "phone",
+          "lazy": false
+        },
+        {
+          "name": "loginLowerCase",
+          "lazy": false
+        },
+        {
+          "name": "password",
+          "lazy": false
+        },
+        {
+          "name": "passwordEncryption",
+          "lazy": false
+        },
+        {
+          "name": "firstName",
+          "lazy": false
+        },
+        {
+          "name": "lastName",
+          "lazy": false
+        },
+        {
+          "name": "middleName",
+          "lazy": false
+        },
+        {
+          "name": "position",
+          "lazy": false
+        },
+        {
+          "name": "email",
+          "lazy": false
+        },
+        {
+          "name": "language",
+          "lazy": false
+        },
+        {
+          "name": "timeZone",
+          "lazy": false
+        },
+        {
+          "name": "timeZoneAuto",
+          "lazy": false
+        },
+        {
+          "name": "active",
+          "lazy": false
+        },
+        {
+          "name": "changePasswordAtNextLogon",
+          "lazy": false
+        },
+        {
+          "name": "groupNames",
+          "lazy": false
+        },
+        {
+          "name": "ipMask",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "login",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "phone",
+          "lazy": false
+        },
+        {
+          "name": "loginLowerCase",
+          "lazy": false
+        },
+        {
+          "name": "password",
+          "lazy": false
+        },
+        {
+          "name": "passwordEncryption",
+          "lazy": false
+        },
+        {
+          "name": "firstName",
+          "lazy": false
+        },
+        {
+          "name": "lastName",
+          "lazy": false
+        },
+        {
+          "name": "middleName",
+          "lazy": false
+        },
+        {
+          "name": "position",
+          "lazy": false
+        },
+        {
+          "name": "email",
+          "lazy": false
+        },
+        {
+          "name": "language",
+          "lazy": false
+        },
+        {
+          "name": "timeZone",
+          "lazy": false
+        },
+        {
+          "name": "timeZoneAuto",
+          "lazy": false
+        },
+        {
+          "name": "active",
+          "lazy": false
+        },
+        {
+          "name": "changePasswordAtNextLogon",
+          "lazy": false
+        },
+        {
+          "name": "groupNames",
+          "lazy": false
+        },
+        {
+          "name": "ipMask",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$InfoParamEntity",
+      "classFqn": "com.haulmont.cuba.gui.app.core.showinfo.InfoParamEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "keyValue",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "keyValue",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_local",
+      "entity": "sys$InfoParamEntity",
+      "classFqn": "com.haulmont.cuba.gui.app.core.showinfo.InfoParamEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sys$InfoParamEntity",
+      "classFqn": "com.haulmont.cuba.gui.app.core.showinfo.InfoParamEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "keyValue",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "keyValue",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$ScreenComponentDescriptor",
+      "classFqn": "com.haulmont.cuba.gui.components.ScreenComponentDescriptor",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$ScreenComponentDescriptor",
+      "classFqn": "com.haulmont.cuba.gui.components.ScreenComponentDescriptor",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sec$ScreenComponentDescriptor",
+      "classFqn": "com.haulmont.cuba.gui.components.ScreenComponentDescriptor",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$ScheduledExecution",
+      "classFqn": "com.haulmont.cuba.core.entity.ScheduledExecution",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$ScheduledExecution",
+      "classFqn": "com.haulmont.cuba.core.entity.ScheduledExecution",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "server",
+          "lazy": false
+        },
+        {
+          "name": "startTime",
+          "lazy": false
+        },
+        {
+          "name": "finishTime",
+          "lazy": false
+        },
+        {
+          "name": "result",
+          "lazy": false
+        },
+        {
+          "name": "durationSec",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "server",
+          "lazy": false
+        },
+        {
+          "name": "startTime",
+          "lazy": false
+        },
+        {
+          "name": "finishTime",
+          "lazy": false
+        },
+        {
+          "name": "result",
+          "lazy": false
+        },
+        {
+          "name": "durationSec",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sys$ScheduledExecution",
+      "classFqn": "com.haulmont.cuba.core.entity.ScheduledExecution",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "server",
+          "lazy": false
+        },
+        {
+          "name": "startTime",
+          "lazy": false
+        },
+        {
+          "name": "finishTime",
+          "lazy": false
+        },
+        {
+          "name": "result",
+          "lazy": false
+        },
+        {
+          "name": "durationSec",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "server",
+          "lazy": false
+        },
+        {
+          "name": "startTime",
+          "lazy": false
+        },
+        {
+          "name": "finishTime",
+          "lazy": false
+        },
+        {
+          "name": "result",
+          "lazy": false
+        },
+        {
+          "name": "durationSec",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$EntityPropertyDiff",
+      "classFqn": "com.haulmont.cuba.core.entity.diff.EntityPropertyDiff",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$EntityPropertyDiff",
+      "classFqn": "com.haulmont.cuba.core.entity.diff.EntityPropertyDiff",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sys$EntityPropertyDiff",
+      "classFqn": "com.haulmont.cuba.core.entity.diff.EntityPropertyDiff",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$Category",
+      "classFqn": "com.haulmont.cuba.core.entity.Category",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "localeName",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "localeName",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_local",
+      "entity": "sys$Category",
+      "classFqn": "com.haulmont.cuba.core.entity.Category",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "entityType",
+          "lazy": false
+        },
+        {
+          "name": "isDefault",
+          "lazy": false
+        },
+        {
+          "name": "localeNames",
+          "lazy": false
+        },
+        {
+          "name": "special",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "entityType",
+          "lazy": false
+        },
+        {
+          "name": "isDefault",
+          "lazy": false
+        },
+        {
+          "name": "localeNames",
+          "lazy": false
+        },
+        {
+          "name": "special",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sys$Category",
+      "classFqn": "com.haulmont.cuba.core.entity.Category",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "localeName",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "entityType",
+          "lazy": false
+        },
+        {
+          "name": "isDefault",
+          "lazy": false
+        },
+        {
+          "name": "localeNames",
+          "lazy": false
+        },
+        {
+          "name": "special",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "localeName",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "entityType",
+          "lazy": false
+        },
+        {
+          "name": "isDefault",
+          "lazy": false
+        },
+        {
+          "name": "localeNames",
+          "lazy": false
+        },
+        {
+          "name": "special",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "category.edit",
+      "entity": "sys$Category",
+      "classFqn": "com.haulmont.cuba.core.entity.Category",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "categoryAttrs",
+          "entity": "sys$CategoryAttribute",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "entityType",
+          "lazy": false
+        },
+        {
+          "name": "isDefault",
+          "lazy": false
+        },
+        {
+          "name": "localeNames",
+          "lazy": false
+        },
+        {
+          "name": "special",
+          "lazy": false
+        },
+        {
+          "name": "categoryAttrs",
+          "entity": "sys$CategoryAttribute",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "category.defaultEdit",
+      "entity": "sys$Category",
+      "classFqn": "com.haulmont.cuba.core.entity.Category",
+      "parentName": "_minimal",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "isDefault",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "localeName",
+          "lazy": false
+        },
+        {
+          "name": "isDefault",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "for.cache",
+      "entity": "sys$Category",
+      "classFqn": "com.haulmont.cuba.core.entity.Category",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "categoryAttrs",
+          "entity": "sys$CategoryAttribute",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "entityType",
+          "lazy": false
+        },
+        {
+          "name": "isDefault",
+          "lazy": false
+        },
+        {
+          "name": "localeNames",
+          "lazy": false
+        },
+        {
+          "name": "special",
+          "lazy": false
+        },
+        {
+          "name": "categoryAttrs",
+          "entity": "sys$CategoryAttribute",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$CustomConditionCreator",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.descriptor.CustomConditionCreator",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$CustomConditionCreator",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.descriptor.CustomConditionCreator",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sec$CustomConditionCreator",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.descriptor.CustomConditionCreator",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "classFqn": "com.haulmont.cuba.core.entity.AbstractSearchFolder",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "classFqn": "com.haulmont.cuba.core.entity.AbstractSearchFolder",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "filterComponentId",
+          "lazy": false
+        },
+        {
+          "name": "filterXml",
+          "lazy": false
+        },
+        {
+          "name": "applyDefault",
+          "lazy": false
+        },
+        {
+          "name": "locName",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "sortOrder",
+          "lazy": false
+        },
+        {
+          "name": "tabName",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "filterComponentId",
+          "lazy": false
+        },
+        {
+          "name": "filterXml",
+          "lazy": false
+        },
+        {
+          "name": "applyDefault",
+          "lazy": false
+        },
+        {
+          "name": "locName",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "sortOrder",
+          "lazy": false
+        },
+        {
+          "name": "tabName",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "classFqn": "com.haulmont.cuba.core.entity.AbstractSearchFolder",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "filterComponentId",
+          "lazy": false
+        },
+        {
+          "name": "filterXml",
+          "lazy": false
+        },
+        {
+          "name": "applyDefault",
+          "lazy": false
+        },
+        {
+          "name": "locName",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "sortOrder",
+          "lazy": false
+        },
+        {
+          "name": "tabName",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "filterComponentId",
+          "lazy": false
+        },
+        {
+          "name": "filterXml",
+          "lazy": false
+        },
+        {
+          "name": "applyDefault",
+          "lazy": false
+        },
+        {
+          "name": "locName",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "sortOrder",
+          "lazy": false
+        },
+        {
+          "name": "tabName",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$AbstractTarget",
+      "classFqn": "com.haulmont.cuba.gui.app.security.entity.AbstractPermissionTarget",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$AbstractTarget",
+      "classFqn": "com.haulmont.cuba.gui.app.security.entity.AbstractPermissionTarget",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sec$AbstractTarget",
+      "classFqn": "com.haulmont.cuba.gui.app.security.entity.AbstractPermissionTarget",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$JmxInstance",
+      "classFqn": "com.haulmont.cuba.core.entity.JmxInstance",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "nodeName",
+          "lazy": false
+        },
+        {
+          "name": "address",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "nodeName",
+          "lazy": false
+        },
+        {
+          "name": "address",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_local",
+      "entity": "sys$JmxInstance",
+      "classFqn": "com.haulmont.cuba.core.entity.JmxInstance",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "nodeName",
+          "lazy": false
+        },
+        {
+          "name": "address",
+          "lazy": false
+        },
+        {
+          "name": "login",
+          "lazy": false
+        },
+        {
+          "name": "password",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "nodeName",
+          "lazy": false
+        },
+        {
+          "name": "address",
+          "lazy": false
+        },
+        {
+          "name": "login",
+          "lazy": false
+        },
+        {
+          "name": "password",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sys$JmxInstance",
+      "classFqn": "com.haulmont.cuba.core.entity.JmxInstance",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "nodeName",
+          "lazy": false
+        },
+        {
+          "name": "address",
+          "lazy": false
+        },
+        {
+          "name": "login",
+          "lazy": false
+        },
+        {
+          "name": "password",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "nodeName",
+          "lazy": false
+        },
+        {
+          "name": "address",
+          "lazy": false
+        },
+        {
+          "name": "login",
+          "lazy": false
+        },
+        {
+          "name": "password",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$BaseIntegerIdEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.BaseIntegerIdEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$BaseIntegerIdEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.BaseIntegerIdEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sys$BaseIntegerIdEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.BaseIntegerIdEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$UiTarget",
+      "classFqn": "com.haulmont.cuba.gui.app.security.entity.UiPermissionTarget",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$UiTarget",
+      "classFqn": "com.haulmont.cuba.gui.app.security.entity.UiPermissionTarget",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sec$UiTarget",
+      "classFqn": "com.haulmont.cuba.gui.app.security.entity.UiPermissionTarget",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$LoggedAttribute",
+      "classFqn": "com.haulmont.cuba.security.entity.LoggedAttribute",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$LoggedAttribute",
+      "classFqn": "com.haulmont.cuba.security.entity.LoggedAttribute",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sec$LoggedAttribute",
+      "classFqn": "com.haulmont.cuba.security.entity.LoggedAttribute",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$AbstractConditionDescriptor",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.descriptor.AbstractConditionDescriptor",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$AbstractConditionDescriptor",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.descriptor.AbstractConditionDescriptor",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sec$AbstractConditionDescriptor",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.descriptor.AbstractConditionDescriptor",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$Group",
+      "classFqn": "com.haulmont.cuba.security.entity.Group",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_local",
+      "entity": "sec$Group",
+      "classFqn": "com.haulmont.cuba.security.entity.Group",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sec$Group",
+      "classFqn": "com.haulmont.cuba.security.entity.Group",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "group.lookup",
+      "entity": "sec$Group",
+      "classFqn": "com.haulmont.cuba.security.entity.Group",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "group.browse",
+      "entity": "sec$Group",
+      "classFqn": "com.haulmont.cuba.security.entity.Group",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "parent",
+          "entity": "sec$Group",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "parent",
+          "entity": "sec$Group",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "group.edit",
+      "entity": "sec$Group",
+      "classFqn": "com.haulmont.cuba.security.entity.Group",
+      "parentName": "group.browse",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "constraints",
+          "entity": "sec$Constraint",
+          "lazy": false
+        },
+        {
+          "name": "sessionAttributes",
+          "entity": "sec$SessionAttribute",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "parent",
+          "entity": "sec$Group",
+          "lazy": false
+        },
+        {
+          "name": "constraints",
+          "entity": "sec$Constraint",
+          "lazy": false
+        },
+        {
+          "name": "sessionAttributes",
+          "entity": "sec$SessionAttribute",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "group.copy",
+      "entity": "sec$Group",
+      "classFqn": "com.haulmont.cuba.security.entity.Group",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "parent",
+          "entity": "sec$Group",
+          "lazy": false
+        },
+        {
+          "name": "constraints",
+          "entity": "sec$Constraint",
+          "lazy": false
+        },
+        {
+          "name": "sessionAttributes",
+          "entity": "sec$SessionAttribute",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "parent",
+          "entity": "sec$Group",
+          "lazy": false
+        },
+        {
+          "name": "constraints",
+          "entity": "sec$Constraint",
+          "lazy": false
+        },
+        {
+          "name": "sessionAttributes",
+          "entity": "sec$SessionAttribute",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "group.export",
+      "entity": "sec$Group",
+      "classFqn": "com.haulmont.cuba.security.entity.Group",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "parent",
+          "entity": "sec$Group",
+          "lazy": false
+        },
+        {
+          "name": "constraints",
+          "entity": "sec$Constraint",
+          "lazy": false
+        },
+        {
+          "name": "sessionAttributes",
+          "entity": "sec$SessionAttribute",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "parent",
+          "entity": "sec$Group",
+          "lazy": false
+        },
+        {
+          "name": "constraints",
+          "entity": "sec$Constraint",
+          "lazy": false
+        },
+        {
+          "name": "sessionAttributes",
+          "entity": "sec$SessionAttribute",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$CustomCondition",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.condition.CustomCondition",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$CustomCondition",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.condition.CustomCondition",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sec$CustomCondition",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.condition.CustomCondition",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$PropertyCondition",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.condition.PropertyCondition",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$PropertyCondition",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.condition.PropertyCondition",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sec$PropertyCondition",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.condition.PropertyCondition",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$Folder",
+      "classFqn": "com.haulmont.cuba.core.entity.Folder",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$Folder",
+      "classFqn": "com.haulmont.cuba.core.entity.Folder",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "sortOrder",
+          "lazy": false
+        },
+        {
+          "name": "tabName",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "sortOrder",
+          "lazy": false
+        },
+        {
+          "name": "tabName",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sys$Folder",
+      "classFqn": "com.haulmont.cuba.core.entity.Folder",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "sortOrder",
+          "lazy": false
+        },
+        {
+          "name": "tabName",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "sortOrder",
+          "lazy": false
+        },
+        {
+          "name": "tabName",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$Role",
+      "classFqn": "com.haulmont.cuba.security.entity.Role",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "locName",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "locName",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_local",
+      "entity": "sec$Role",
+      "classFqn": "com.haulmont.cuba.security.entity.Role",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "locName",
+          "lazy": false
+        },
+        {
+          "name": "description",
+          "lazy": false
+        },
+        {
+          "name": "type",
+          "lazy": false
+        },
+        {
+          "name": "defaultRole",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "securityScope",
+          "lazy": false
+        },
+        {
+          "name": "defaultScreenAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntityCreateAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntityReadAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntityUpdateAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntityDeleteAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntityAttributeAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultSpecificAccess",
+          "lazy": false
+        },
+        {
+          "name": "locSecurityScope",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "locName",
+          "lazy": false
+        },
+        {
+          "name": "description",
+          "lazy": false
+        },
+        {
+          "name": "type",
+          "lazy": false
+        },
+        {
+          "name": "defaultRole",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "securityScope",
+          "lazy": false
+        },
+        {
+          "name": "defaultScreenAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntityCreateAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntityReadAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntityUpdateAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntityDeleteAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntityAttributeAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultSpecificAccess",
+          "lazy": false
+        },
+        {
+          "name": "locSecurityScope",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sec$Role",
+      "classFqn": "com.haulmont.cuba.security.entity.Role",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "locName",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "description",
+          "lazy": false
+        },
+        {
+          "name": "type",
+          "lazy": false
+        },
+        {
+          "name": "defaultRole",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "securityScope",
+          "lazy": false
+        },
+        {
+          "name": "defaultScreenAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntityCreateAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntityReadAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntityUpdateAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntityDeleteAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntityAttributeAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultSpecificAccess",
+          "lazy": false
+        },
+        {
+          "name": "locSecurityScope",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "locName",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "description",
+          "lazy": false
+        },
+        {
+          "name": "type",
+          "lazy": false
+        },
+        {
+          "name": "defaultRole",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "securityScope",
+          "lazy": false
+        },
+        {
+          "name": "defaultScreenAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntityCreateAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntityReadAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntityUpdateAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntityDeleteAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntityAttributeAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultSpecificAccess",
+          "lazy": false
+        },
+        {
+          "name": "locSecurityScope",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "role.lookup",
+      "entity": "sec$Role",
+      "classFqn": "com.haulmont.cuba.security.entity.Role",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "role.browse",
+      "entity": "sec$Role",
+      "classFqn": "com.haulmont.cuba.security.entity.Role",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "role.edit",
+      "entity": "sec$Role",
+      "classFqn": "com.haulmont.cuba.security.entity.Role",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "type",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "type",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "role.export",
+      "entity": "sec$Role",
+      "classFqn": "com.haulmont.cuba.security.entity.Role",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "permissions",
+          "entity": "sec$Permission",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "locName",
+          "lazy": false
+        },
+        {
+          "name": "description",
+          "lazy": false
+        },
+        {
+          "name": "type",
+          "lazy": false
+        },
+        {
+          "name": "defaultRole",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "securityScope",
+          "lazy": false
+        },
+        {
+          "name": "defaultScreenAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntityCreateAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntityReadAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntityUpdateAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntityDeleteAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntityAttributeAccess",
+          "lazy": false
+        },
+        {
+          "name": "defaultSpecificAccess",
+          "lazy": false
+        },
+        {
+          "name": "locSecurityScope",
+          "lazy": false
+        },
+        {
+          "name": "permissions",
+          "entity": "sec$Permission",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "role.copy",
+      "entity": "sec$Role",
+      "classFqn": "com.haulmont.cuba.security.entity.Role",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "type",
+          "lazy": false
+        },
+        {
+          "name": "locName",
+          "lazy": false
+        },
+        {
+          "name": "permissions",
+          "entity": "sec$Permission",
+          "lazy": false
+        },
+        {
+          "name": "description",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "type",
+          "lazy": false
+        },
+        {
+          "name": "locName",
+          "lazy": false
+        },
+        {
+          "name": "permissions",
+          "entity": "sec$Permission",
+          "lazy": false
+        },
+        {
+          "name": "description",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$GroupHierarchy",
+      "classFqn": "com.haulmont.cuba.security.entity.GroupHierarchy",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$GroupHierarchy",
+      "classFqn": "com.haulmont.cuba.security.entity.GroupHierarchy",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "level",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "level",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sec$GroupHierarchy",
+      "classFqn": "com.haulmont.cuba.security.entity.GroupHierarchy",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "level",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "level",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$ScreenAndComponent",
+      "classFqn": "com.haulmont.cuba.gui.app.core.categories.ScreenAndComponent",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$ScreenAndComponent",
+      "classFqn": "com.haulmont.cuba.gui.app.core.categories.ScreenAndComponent",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sys$ScreenAndComponent",
+      "classFqn": "com.haulmont.cuba.gui.app.core.categories.ScreenAndComponent",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$AppPropertyEntity",
+      "classFqn": "com.haulmont.cuba.core.config.AppPropertyEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$AppPropertyEntity",
+      "classFqn": "com.haulmont.cuba.core.config.AppPropertyEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sys$AppPropertyEntity",
+      "classFqn": "com.haulmont.cuba.core.config.AppPropertyEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$BaseDbGeneratedIdEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.BaseDbGeneratedIdEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$BaseDbGeneratedIdEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.BaseDbGeneratedIdEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sys$BaseDbGeneratedIdEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.BaseDbGeneratedIdEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$Constraint",
+      "classFqn": "com.haulmont.cuba.security.entity.Constraint",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$Constraint",
+      "classFqn": "com.haulmont.cuba.security.entity.Constraint",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "checkType",
+          "lazy": false
+        },
+        {
+          "name": "operationType",
+          "lazy": false
+        },
+        {
+          "name": "code",
+          "lazy": false
+        },
+        {
+          "name": "entityName",
+          "lazy": false
+        },
+        {
+          "name": "joinClause",
+          "lazy": false
+        },
+        {
+          "name": "whereClause",
+          "lazy": false
+        },
+        {
+          "name": "groovyScript",
+          "lazy": false
+        },
+        {
+          "name": "filterXml",
+          "lazy": false
+        },
+        {
+          "name": "isActive",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "checkType",
+          "lazy": false
+        },
+        {
+          "name": "operationType",
+          "lazy": false
+        },
+        {
+          "name": "code",
+          "lazy": false
+        },
+        {
+          "name": "entityName",
+          "lazy": false
+        },
+        {
+          "name": "joinClause",
+          "lazy": false
+        },
+        {
+          "name": "whereClause",
+          "lazy": false
+        },
+        {
+          "name": "groovyScript",
+          "lazy": false
+        },
+        {
+          "name": "filterXml",
+          "lazy": false
+        },
+        {
+          "name": "isActive",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sec$Constraint",
+      "classFqn": "com.haulmont.cuba.security.entity.Constraint",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "checkType",
+          "lazy": false
+        },
+        {
+          "name": "operationType",
+          "lazy": false
+        },
+        {
+          "name": "code",
+          "lazy": false
+        },
+        {
+          "name": "entityName",
+          "lazy": false
+        },
+        {
+          "name": "joinClause",
+          "lazy": false
+        },
+        {
+          "name": "whereClause",
+          "lazy": false
+        },
+        {
+          "name": "groovyScript",
+          "lazy": false
+        },
+        {
+          "name": "filterXml",
+          "lazy": false
+        },
+        {
+          "name": "isActive",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "checkType",
+          "lazy": false
+        },
+        {
+          "name": "operationType",
+          "lazy": false
+        },
+        {
+          "name": "code",
+          "lazy": false
+        },
+        {
+          "name": "entityName",
+          "lazy": false
+        },
+        {
+          "name": "joinClause",
+          "lazy": false
+        },
+        {
+          "name": "whereClause",
+          "lazy": false
+        },
+        {
+          "name": "groovyScript",
+          "lazy": false
+        },
+        {
+          "name": "filterXml",
+          "lazy": false
+        },
+        {
+          "name": "isActive",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "group.browse",
+      "entity": "sec$Constraint",
+      "classFqn": "com.haulmont.cuba.security.entity.Constraint",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "group",
+          "entity": "sec$Group",
+          "lazy": false
+        },
+        {
+          "name": "entityName",
+          "lazy": false
+        },
+        {
+          "name": "isActive",
+          "lazy": false
+        },
+        {
+          "name": "operationType",
+          "lazy": false
+        },
+        {
+          "name": "joinClause",
+          "lazy": false
+        },
+        {
+          "name": "whereClause",
+          "lazy": false
+        },
+        {
+          "name": "groovyScript",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "group",
+          "entity": "sec$Group",
+          "lazy": false
+        },
+        {
+          "name": "entityName",
+          "lazy": false
+        },
+        {
+          "name": "isActive",
+          "lazy": false
+        },
+        {
+          "name": "operationType",
+          "lazy": false
+        },
+        {
+          "name": "joinClause",
+          "lazy": false
+        },
+        {
+          "name": "whereClause",
+          "lazy": false
+        },
+        {
+          "name": "groovyScript",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "edit",
+      "entity": "sec$Constraint",
+      "classFqn": "com.haulmont.cuba.security.entity.Constraint",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "entityName",
+          "lazy": false
+        },
+        {
+          "name": "isActive",
+          "lazy": false
+        },
+        {
+          "name": "code",
+          "lazy": false
+        },
+        {
+          "name": "checkType",
+          "lazy": false
+        },
+        {
+          "name": "operationType",
+          "lazy": false
+        },
+        {
+          "name": "joinClause",
+          "lazy": false
+        },
+        {
+          "name": "whereClause",
+          "lazy": false
+        },
+        {
+          "name": "groovyScript",
+          "lazy": false
+        },
+        {
+          "name": "filterXml",
+          "lazy": false
+        },
+        {
+          "name": "group",
+          "entity": "sec$Group",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "entityName",
+          "lazy": false
+        },
+        {
+          "name": "isActive",
+          "lazy": false
+        },
+        {
+          "name": "code",
+          "lazy": false
+        },
+        {
+          "name": "checkType",
+          "lazy": false
+        },
+        {
+          "name": "operationType",
+          "lazy": false
+        },
+        {
+          "name": "joinClause",
+          "lazy": false
+        },
+        {
+          "name": "whereClause",
+          "lazy": false
+        },
+        {
+          "name": "groovyScript",
+          "lazy": false
+        },
+        {
+          "name": "filterXml",
+          "lazy": false
+        },
+        {
+          "name": "group",
+          "entity": "sec$Group",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$KeyValueEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.KeyValueEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$KeyValueEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.KeyValueEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sys$KeyValueEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.KeyValueEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$Config",
+      "classFqn": "com.haulmont.cuba.core.entity.Config",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$Config",
+      "classFqn": "com.haulmont.cuba.core.entity.Config",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "value",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "value",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sys$Config",
+      "classFqn": "com.haulmont.cuba.core.entity.Config",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "value",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "value",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "appProperties",
+      "entity": "sys$Config",
+      "classFqn": "com.haulmont.cuba.core.entity.Config",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": true,
+      "properties": [],
+      "allProperties": [
+        {
+          "name": "id",
+          "lazy": false
+        },
+        {
+          "name": "version",
+          "lazy": false
+        },
+        {
+          "name": "createTs",
+          "lazy": false
+        },
+        {
+          "name": "createdBy",
+          "lazy": false
+        },
+        {
+          "name": "updateTs",
+          "lazy": false
+        },
+        {
+          "name": "updatedBy",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "value",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$GroupCondition",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.condition.GroupCondition",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$GroupCondition",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.condition.GroupCondition",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sec$GroupCondition",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.condition.GroupCondition",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$AttributeTarget",
+      "classFqn": "com.haulmont.cuba.gui.app.security.entity.AttributeTarget",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$AttributeTarget",
+      "classFqn": "com.haulmont.cuba.gui.app.security.entity.AttributeTarget",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sec$AttributeTarget",
+      "classFqn": "com.haulmont.cuba.gui.app.security.entity.AttributeTarget",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$PropertyConditionDescriptor",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.descriptor.PropertyConditionDescriptor",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$PropertyConditionDescriptor",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.descriptor.PropertyConditionDescriptor",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sec$PropertyConditionDescriptor",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.descriptor.PropertyConditionDescriptor",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$HeaderConditionDescriptor",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.descriptor.HeaderConditionDescriptor",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$HeaderConditionDescriptor",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.descriptor.HeaderConditionDescriptor",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sec$HeaderConditionDescriptor",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.descriptor.HeaderConditionDescriptor",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$EntityDiff",
+      "classFqn": "com.haulmont.cuba.core.entity.diff.EntityDiff",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$EntityDiff",
+      "classFqn": "com.haulmont.cuba.core.entity.diff.EntityDiff",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sys$EntityDiff",
+      "classFqn": "com.haulmont.cuba.core.entity.diff.EntityDiff",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$EntityLogAttr",
+      "classFqn": "com.haulmont.cuba.security.entity.EntityLogAttr",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$EntityLogAttr",
+      "classFqn": "com.haulmont.cuba.security.entity.EntityLogAttr",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sec$EntityLogAttr",
+      "classFqn": "com.haulmont.cuba.security.entity.EntityLogAttr",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$BaseLongIdEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.BaseLongIdEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$BaseLongIdEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.BaseLongIdEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sys$BaseLongIdEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.BaseLongIdEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "jmxcontrol$ManagedBeanDomain",
+      "classFqn": "com.haulmont.cuba.web.jmx.entity.ManagedBeanDomain",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "jmxcontrol$ManagedBeanDomain",
+      "classFqn": "com.haulmont.cuba.web.jmx.entity.ManagedBeanDomain",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "jmxcontrol$ManagedBeanDomain",
+      "classFqn": "com.haulmont.cuba.web.jmx.entity.ManagedBeanDomain",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$BaseStringIdEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.BaseStringIdEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$BaseStringIdEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.BaseStringIdEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sys$BaseStringIdEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.BaseStringIdEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$EntityBasicPropertyDiff",
+      "classFqn": "com.haulmont.cuba.core.entity.diff.EntityBasicPropertyDiff",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$EntityBasicPropertyDiff",
+      "classFqn": "com.haulmont.cuba.core.entity.diff.EntityBasicPropertyDiff",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sys$EntityBasicPropertyDiff",
+      "classFqn": "com.haulmont.cuba.core.entity.diff.EntityBasicPropertyDiff",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$AppFolder",
+      "classFqn": "com.haulmont.cuba.core.entity.AppFolder",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$AppFolder",
+      "classFqn": "com.haulmont.cuba.core.entity.AppFolder",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "visibilityScript",
+          "lazy": false
+        },
+        {
+          "name": "quantityScript",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "sortOrder",
+          "lazy": false
+        },
+        {
+          "name": "tabName",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "filterComponentId",
+          "lazy": false
+        },
+        {
+          "name": "filterXml",
+          "lazy": false
+        },
+        {
+          "name": "applyDefault",
+          "lazy": false
+        },
+        {
+          "name": "locName",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "visibilityScript",
+          "lazy": false
+        },
+        {
+          "name": "quantityScript",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "sortOrder",
+          "lazy": false
+        },
+        {
+          "name": "tabName",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "filterComponentId",
+          "lazy": false
+        },
+        {
+          "name": "filterXml",
+          "lazy": false
+        },
+        {
+          "name": "applyDefault",
+          "lazy": false
+        },
+        {
+          "name": "locName",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sys$AppFolder",
+      "classFqn": "com.haulmont.cuba.core.entity.AppFolder",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "visibilityScript",
+          "lazy": false
+        },
+        {
+          "name": "quantityScript",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "sortOrder",
+          "lazy": false
+        },
+        {
+          "name": "tabName",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "filterComponentId",
+          "lazy": false
+        },
+        {
+          "name": "filterXml",
+          "lazy": false
+        },
+        {
+          "name": "applyDefault",
+          "lazy": false
+        },
+        {
+          "name": "locName",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "visibilityScript",
+          "lazy": false
+        },
+        {
+          "name": "quantityScript",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "sortOrder",
+          "lazy": false
+        },
+        {
+          "name": "tabName",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "filterComponentId",
+          "lazy": false
+        },
+        {
+          "name": "filterXml",
+          "lazy": false
+        },
+        {
+          "name": "applyDefault",
+          "lazy": false
+        },
+        {
+          "name": "locName",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$LockDescriptor",
+      "classFqn": "com.haulmont.cuba.core.entity.LockDescriptor",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$LockDescriptor",
+      "classFqn": "com.haulmont.cuba.core.entity.LockDescriptor",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "timeoutSec",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "timeoutSec",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sys$LockDescriptor",
+      "classFqn": "com.haulmont.cuba.core.entity.LockDescriptor",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "timeoutSec",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "timeoutSec",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$CategorizedEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.CategorizedEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$CategorizedEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.CategorizedEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sys$CategorizedEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.CategorizedEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$EntitySnapshot",
+      "classFqn": "com.haulmont.cuba.core.entity.EntitySnapshot",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$EntitySnapshot",
+      "classFqn": "com.haulmont.cuba.core.entity.EntitySnapshot",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "viewXml",
+          "lazy": false
+        },
+        {
+          "name": "snapshotXml",
+          "lazy": false
+        },
+        {
+          "name": "entityMetaClass",
+          "lazy": false
+        },
+        {
+          "name": "snapshotDate",
+          "lazy": false
+        },
+        {
+          "name": "label",
+          "lazy": false
+        },
+        {
+          "name": "changeDate",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "viewXml",
+          "lazy": false
+        },
+        {
+          "name": "snapshotXml",
+          "lazy": false
+        },
+        {
+          "name": "entityMetaClass",
+          "lazy": false
+        },
+        {
+          "name": "snapshotDate",
+          "lazy": false
+        },
+        {
+          "name": "label",
+          "lazy": false
+        },
+        {
+          "name": "changeDate",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sys$EntitySnapshot",
+      "classFqn": "com.haulmont.cuba.core.entity.EntitySnapshot",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "viewXml",
+          "lazy": false
+        },
+        {
+          "name": "snapshotXml",
+          "lazy": false
+        },
+        {
+          "name": "entityMetaClass",
+          "lazy": false
+        },
+        {
+          "name": "snapshotDate",
+          "lazy": false
+        },
+        {
+          "name": "label",
+          "lazy": false
+        },
+        {
+          "name": "changeDate",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "viewXml",
+          "lazy": false
+        },
+        {
+          "name": "snapshotXml",
+          "lazy": false
+        },
+        {
+          "name": "entityMetaClass",
+          "lazy": false
+        },
+        {
+          "name": "snapshotDate",
+          "lazy": false
+        },
+        {
+          "name": "label",
+          "lazy": false
+        },
+        {
+          "name": "changeDate",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "entitySnapshot.browse",
+      "entity": "sys$EntitySnapshot",
+      "classFqn": "com.haulmont.cuba.core.entity.EntitySnapshot",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "createTs",
+          "lazy": false
+        },
+        {
+          "name": "author",
+          "entity": "sec$User",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "viewXml",
+          "lazy": false
+        },
+        {
+          "name": "snapshotXml",
+          "lazy": false
+        },
+        {
+          "name": "entityMetaClass",
+          "lazy": false
+        },
+        {
+          "name": "snapshotDate",
+          "lazy": false
+        },
+        {
+          "name": "label",
+          "lazy": false
+        },
+        {
+          "name": "changeDate",
+          "lazy": false
+        },
+        {
+          "name": "createTs",
+          "lazy": false
+        },
+        {
+          "name": "author",
+          "entity": "sec$User",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$CategoryAttribute",
+      "classFqn": "com.haulmont.cuba.core.entity.CategoryAttribute",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "localeName",
+          "lazy": false
+        },
+        {
+          "name": "code",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "localeName",
+          "lazy": false
+        },
+        {
+          "name": "code",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_local",
+      "entity": "sys$CategoryAttribute",
+      "classFqn": "com.haulmont.cuba.core.entity.CategoryAttribute",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "categoryEntityType",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "code",
+          "lazy": false
+        },
+        {
+          "name": "description",
+          "lazy": false
+        },
+        {
+          "name": "enumeration",
+          "lazy": false
+        },
+        {
+          "name": "dataType",
+          "lazy": false
+        },
+        {
+          "name": "entityClass",
+          "lazy": false
+        },
+        {
+          "name": "orderNo",
+          "lazy": false
+        },
+        {
+          "name": "screen",
+          "lazy": false
+        },
+        {
+          "name": "required",
+          "lazy": false
+        },
+        {
+          "name": "lookup",
+          "lazy": false
+        },
+        {
+          "name": "targetScreens",
+          "lazy": false
+        },
+        {
+          "name": "defaultString",
+          "lazy": false
+        },
+        {
+          "name": "defaultInt",
+          "lazy": false
+        },
+        {
+          "name": "defaultDouble",
+          "lazy": false
+        },
+        {
+          "name": "defaultDecimal",
+          "lazy": false
+        },
+        {
+          "name": "defaultBoolean",
+          "lazy": false
+        },
+        {
+          "name": "defaultDate",
+          "lazy": false
+        },
+        {
+          "name": "defaultDateWithoutTime",
+          "lazy": false
+        },
+        {
+          "name": "defaultDateIsCurrent",
+          "lazy": false
+        },
+        {
+          "name": "width",
+          "lazy": false
+        },
+        {
+          "name": "rowsCount",
+          "lazy": false
+        },
+        {
+          "name": "isCollection",
+          "lazy": false
+        },
+        {
+          "name": "whereClause",
+          "lazy": false
+        },
+        {
+          "name": "joinClause",
+          "lazy": false
+        },
+        {
+          "name": "filterXml",
+          "lazy": false
+        },
+        {
+          "name": "localeNames",
+          "lazy": false
+        },
+        {
+          "name": "localeDescriptions",
+          "lazy": false
+        },
+        {
+          "name": "enumerationLocales",
+          "lazy": false
+        },
+        {
+          "name": "attributeConfigurationJson",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "categoryEntityType",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "code",
+          "lazy": false
+        },
+        {
+          "name": "description",
+          "lazy": false
+        },
+        {
+          "name": "enumeration",
+          "lazy": false
+        },
+        {
+          "name": "dataType",
+          "lazy": false
+        },
+        {
+          "name": "entityClass",
+          "lazy": false
+        },
+        {
+          "name": "orderNo",
+          "lazy": false
+        },
+        {
+          "name": "screen",
+          "lazy": false
+        },
+        {
+          "name": "required",
+          "lazy": false
+        },
+        {
+          "name": "lookup",
+          "lazy": false
+        },
+        {
+          "name": "targetScreens",
+          "lazy": false
+        },
+        {
+          "name": "defaultString",
+          "lazy": false
+        },
+        {
+          "name": "defaultInt",
+          "lazy": false
+        },
+        {
+          "name": "defaultDouble",
+          "lazy": false
+        },
+        {
+          "name": "defaultDecimal",
+          "lazy": false
+        },
+        {
+          "name": "defaultBoolean",
+          "lazy": false
+        },
+        {
+          "name": "defaultDate",
+          "lazy": false
+        },
+        {
+          "name": "defaultDateWithoutTime",
+          "lazy": false
+        },
+        {
+          "name": "defaultDateIsCurrent",
+          "lazy": false
+        },
+        {
+          "name": "width",
+          "lazy": false
+        },
+        {
+          "name": "rowsCount",
+          "lazy": false
+        },
+        {
+          "name": "isCollection",
+          "lazy": false
+        },
+        {
+          "name": "whereClause",
+          "lazy": false
+        },
+        {
+          "name": "joinClause",
+          "lazy": false
+        },
+        {
+          "name": "filterXml",
+          "lazy": false
+        },
+        {
+          "name": "localeNames",
+          "lazy": false
+        },
+        {
+          "name": "localeDescriptions",
+          "lazy": false
+        },
+        {
+          "name": "enumerationLocales",
+          "lazy": false
+        },
+        {
+          "name": "attributeConfigurationJson",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sys$CategoryAttribute",
+      "classFqn": "com.haulmont.cuba.core.entity.CategoryAttribute",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "localeName",
+          "lazy": false
+        },
+        {
+          "name": "code",
+          "lazy": false
+        },
+        {
+          "name": "categoryEntityType",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "description",
+          "lazy": false
+        },
+        {
+          "name": "enumeration",
+          "lazy": false
+        },
+        {
+          "name": "dataType",
+          "lazy": false
+        },
+        {
+          "name": "entityClass",
+          "lazy": false
+        },
+        {
+          "name": "orderNo",
+          "lazy": false
+        },
+        {
+          "name": "screen",
+          "lazy": false
+        },
+        {
+          "name": "required",
+          "lazy": false
+        },
+        {
+          "name": "lookup",
+          "lazy": false
+        },
+        {
+          "name": "targetScreens",
+          "lazy": false
+        },
+        {
+          "name": "defaultString",
+          "lazy": false
+        },
+        {
+          "name": "defaultInt",
+          "lazy": false
+        },
+        {
+          "name": "defaultDouble",
+          "lazy": false
+        },
+        {
+          "name": "defaultDecimal",
+          "lazy": false
+        },
+        {
+          "name": "defaultBoolean",
+          "lazy": false
+        },
+        {
+          "name": "defaultDate",
+          "lazy": false
+        },
+        {
+          "name": "defaultDateWithoutTime",
+          "lazy": false
+        },
+        {
+          "name": "defaultDateIsCurrent",
+          "lazy": false
+        },
+        {
+          "name": "width",
+          "lazy": false
+        },
+        {
+          "name": "rowsCount",
+          "lazy": false
+        },
+        {
+          "name": "isCollection",
+          "lazy": false
+        },
+        {
+          "name": "whereClause",
+          "lazy": false
+        },
+        {
+          "name": "joinClause",
+          "lazy": false
+        },
+        {
+          "name": "filterXml",
+          "lazy": false
+        },
+        {
+          "name": "localeNames",
+          "lazy": false
+        },
+        {
+          "name": "localeDescriptions",
+          "lazy": false
+        },
+        {
+          "name": "enumerationLocales",
+          "lazy": false
+        },
+        {
+          "name": "attributeConfigurationJson",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "localeName",
+          "lazy": false
+        },
+        {
+          "name": "code",
+          "lazy": false
+        },
+        {
+          "name": "categoryEntityType",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "description",
+          "lazy": false
+        },
+        {
+          "name": "enumeration",
+          "lazy": false
+        },
+        {
+          "name": "dataType",
+          "lazy": false
+        },
+        {
+          "name": "entityClass",
+          "lazy": false
+        },
+        {
+          "name": "orderNo",
+          "lazy": false
+        },
+        {
+          "name": "screen",
+          "lazy": false
+        },
+        {
+          "name": "required",
+          "lazy": false
+        },
+        {
+          "name": "lookup",
+          "lazy": false
+        },
+        {
+          "name": "targetScreens",
+          "lazy": false
+        },
+        {
+          "name": "defaultString",
+          "lazy": false
+        },
+        {
+          "name": "defaultInt",
+          "lazy": false
+        },
+        {
+          "name": "defaultDouble",
+          "lazy": false
+        },
+        {
+          "name": "defaultDecimal",
+          "lazy": false
+        },
+        {
+          "name": "defaultBoolean",
+          "lazy": false
+        },
+        {
+          "name": "defaultDate",
+          "lazy": false
+        },
+        {
+          "name": "defaultDateWithoutTime",
+          "lazy": false
+        },
+        {
+          "name": "defaultDateIsCurrent",
+          "lazy": false
+        },
+        {
+          "name": "width",
+          "lazy": false
+        },
+        {
+          "name": "rowsCount",
+          "lazy": false
+        },
+        {
+          "name": "isCollection",
+          "lazy": false
+        },
+        {
+          "name": "whereClause",
+          "lazy": false
+        },
+        {
+          "name": "joinClause",
+          "lazy": false
+        },
+        {
+          "name": "filterXml",
+          "lazy": false
+        },
+        {
+          "name": "localeNames",
+          "lazy": false
+        },
+        {
+          "name": "localeDescriptions",
+          "lazy": false
+        },
+        {
+          "name": "enumerationLocales",
+          "lazy": false
+        },
+        {
+          "name": "attributeConfigurationJson",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "categoryAttribute.browse",
+      "entity": "sys$CategoryAttribute",
+      "classFqn": "com.haulmont.cuba.core.entity.CategoryAttribute",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "defaultEntity",
+          "entity": "sys$ReferenceToEntity",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "categoryEntityType",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "code",
+          "lazy": false
+        },
+        {
+          "name": "description",
+          "lazy": false
+        },
+        {
+          "name": "enumeration",
+          "lazy": false
+        },
+        {
+          "name": "dataType",
+          "lazy": false
+        },
+        {
+          "name": "entityClass",
+          "lazy": false
+        },
+        {
+          "name": "orderNo",
+          "lazy": false
+        },
+        {
+          "name": "screen",
+          "lazy": false
+        },
+        {
+          "name": "required",
+          "lazy": false
+        },
+        {
+          "name": "lookup",
+          "lazy": false
+        },
+        {
+          "name": "targetScreens",
+          "lazy": false
+        },
+        {
+          "name": "defaultString",
+          "lazy": false
+        },
+        {
+          "name": "defaultInt",
+          "lazy": false
+        },
+        {
+          "name": "defaultDouble",
+          "lazy": false
+        },
+        {
+          "name": "defaultDecimal",
+          "lazy": false
+        },
+        {
+          "name": "defaultBoolean",
+          "lazy": false
+        },
+        {
+          "name": "defaultDate",
+          "lazy": false
+        },
+        {
+          "name": "defaultDateWithoutTime",
+          "lazy": false
+        },
+        {
+          "name": "defaultDateIsCurrent",
+          "lazy": false
+        },
+        {
+          "name": "width",
+          "lazy": false
+        },
+        {
+          "name": "rowsCount",
+          "lazy": false
+        },
+        {
+          "name": "isCollection",
+          "lazy": false
+        },
+        {
+          "name": "whereClause",
+          "lazy": false
+        },
+        {
+          "name": "joinClause",
+          "lazy": false
+        },
+        {
+          "name": "filterXml",
+          "lazy": false
+        },
+        {
+          "name": "localeNames",
+          "lazy": false
+        },
+        {
+          "name": "localeDescriptions",
+          "lazy": false
+        },
+        {
+          "name": "enumerationLocales",
+          "lazy": false
+        },
+        {
+          "name": "attributeConfigurationJson",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntity",
+          "entity": "sys$ReferenceToEntity",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "category.edit",
+      "entity": "sys$CategoryAttribute",
+      "classFqn": "com.haulmont.cuba.core.entity.CategoryAttribute",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "category",
+          "entity": "sys$Category",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntity",
+          "entity": "sys$ReferenceToEntity",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "categoryEntityType",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "code",
+          "lazy": false
+        },
+        {
+          "name": "description",
+          "lazy": false
+        },
+        {
+          "name": "enumeration",
+          "lazy": false
+        },
+        {
+          "name": "dataType",
+          "lazy": false
+        },
+        {
+          "name": "entityClass",
+          "lazy": false
+        },
+        {
+          "name": "orderNo",
+          "lazy": false
+        },
+        {
+          "name": "screen",
+          "lazy": false
+        },
+        {
+          "name": "required",
+          "lazy": false
+        },
+        {
+          "name": "lookup",
+          "lazy": false
+        },
+        {
+          "name": "targetScreens",
+          "lazy": false
+        },
+        {
+          "name": "defaultString",
+          "lazy": false
+        },
+        {
+          "name": "defaultInt",
+          "lazy": false
+        },
+        {
+          "name": "defaultDouble",
+          "lazy": false
+        },
+        {
+          "name": "defaultDecimal",
+          "lazy": false
+        },
+        {
+          "name": "defaultBoolean",
+          "lazy": false
+        },
+        {
+          "name": "defaultDate",
+          "lazy": false
+        },
+        {
+          "name": "defaultDateWithoutTime",
+          "lazy": false
+        },
+        {
+          "name": "defaultDateIsCurrent",
+          "lazy": false
+        },
+        {
+          "name": "width",
+          "lazy": false
+        },
+        {
+          "name": "rowsCount",
+          "lazy": false
+        },
+        {
+          "name": "isCollection",
+          "lazy": false
+        },
+        {
+          "name": "whereClause",
+          "lazy": false
+        },
+        {
+          "name": "joinClause",
+          "lazy": false
+        },
+        {
+          "name": "filterXml",
+          "lazy": false
+        },
+        {
+          "name": "localeNames",
+          "lazy": false
+        },
+        {
+          "name": "localeDescriptions",
+          "lazy": false
+        },
+        {
+          "name": "enumerationLocales",
+          "lazy": false
+        },
+        {
+          "name": "attributeConfigurationJson",
+          "lazy": false
+        },
+        {
+          "name": "category",
+          "entity": "sys$Category",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntity",
+          "entity": "sys$ReferenceToEntity",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "for.cache",
+      "entity": "sys$CategoryAttribute",
+      "classFqn": "com.haulmont.cuba.core.entity.CategoryAttribute",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "category",
+          "entity": "sys$Category",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntity",
+          "entity": "sys$ReferenceToEntity",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "categoryEntityType",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "code",
+          "lazy": false
+        },
+        {
+          "name": "description",
+          "lazy": false
+        },
+        {
+          "name": "enumeration",
+          "lazy": false
+        },
+        {
+          "name": "dataType",
+          "lazy": false
+        },
+        {
+          "name": "entityClass",
+          "lazy": false
+        },
+        {
+          "name": "orderNo",
+          "lazy": false
+        },
+        {
+          "name": "screen",
+          "lazy": false
+        },
+        {
+          "name": "required",
+          "lazy": false
+        },
+        {
+          "name": "lookup",
+          "lazy": false
+        },
+        {
+          "name": "targetScreens",
+          "lazy": false
+        },
+        {
+          "name": "defaultString",
+          "lazy": false
+        },
+        {
+          "name": "defaultInt",
+          "lazy": false
+        },
+        {
+          "name": "defaultDouble",
+          "lazy": false
+        },
+        {
+          "name": "defaultDecimal",
+          "lazy": false
+        },
+        {
+          "name": "defaultBoolean",
+          "lazy": false
+        },
+        {
+          "name": "defaultDate",
+          "lazy": false
+        },
+        {
+          "name": "defaultDateWithoutTime",
+          "lazy": false
+        },
+        {
+          "name": "defaultDateIsCurrent",
+          "lazy": false
+        },
+        {
+          "name": "width",
+          "lazy": false
+        },
+        {
+          "name": "rowsCount",
+          "lazy": false
+        },
+        {
+          "name": "isCollection",
+          "lazy": false
+        },
+        {
+          "name": "whereClause",
+          "lazy": false
+        },
+        {
+          "name": "joinClause",
+          "lazy": false
+        },
+        {
+          "name": "filterXml",
+          "lazy": false
+        },
+        {
+          "name": "localeNames",
+          "lazy": false
+        },
+        {
+          "name": "localeDescriptions",
+          "lazy": false
+        },
+        {
+          "name": "enumerationLocales",
+          "lazy": false
+        },
+        {
+          "name": "attributeConfigurationJson",
+          "lazy": false
+        },
+        {
+          "name": "category",
+          "entity": "sys$Category",
+          "lazy": false
+        },
+        {
+          "name": "defaultEntity",
+          "entity": "sys$ReferenceToEntity",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "stat$ThreadSnapshot",
+      "classFqn": "com.haulmont.cuba.web.app.ui.statistics.ThreadSnapshot",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "stat$ThreadSnapshot",
+      "classFqn": "com.haulmont.cuba.web.app.ui.statistics.ThreadSnapshot",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "stat$ThreadSnapshot",
+      "classFqn": "com.haulmont.cuba.web.app.ui.statistics.ThreadSnapshot",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$EntityStatistics",
+      "classFqn": "com.haulmont.cuba.core.entity.EntityStatistics",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$EntityStatistics",
+      "classFqn": "com.haulmont.cuba.core.entity.EntityStatistics",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "instanceCount",
+          "lazy": false
+        },
+        {
+          "name": "fetchUI",
+          "lazy": false
+        },
+        {
+          "name": "maxFetchUI",
+          "lazy": false
+        },
+        {
+          "name": "lazyCollectionThreshold",
+          "lazy": false
+        },
+        {
+          "name": "lookupScreenThreshold",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "instanceCount",
+          "lazy": false
+        },
+        {
+          "name": "fetchUI",
+          "lazy": false
+        },
+        {
+          "name": "maxFetchUI",
+          "lazy": false
+        },
+        {
+          "name": "lazyCollectionThreshold",
+          "lazy": false
+        },
+        {
+          "name": "lookupScreenThreshold",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sys$EntityStatistics",
+      "classFqn": "com.haulmont.cuba.core.entity.EntityStatistics",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "instanceCount",
+          "lazy": false
+        },
+        {
+          "name": "fetchUI",
+          "lazy": false
+        },
+        {
+          "name": "maxFetchUI",
+          "lazy": false
+        },
+        {
+          "name": "lazyCollectionThreshold",
+          "lazy": false
+        },
+        {
+          "name": "lookupScreenThreshold",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "instanceCount",
+          "lazy": false
+        },
+        {
+          "name": "fetchUI",
+          "lazy": false
+        },
+        {
+          "name": "maxFetchUI",
+          "lazy": false
+        },
+        {
+          "name": "lazyCollectionThreshold",
+          "lazy": false
+        },
+        {
+          "name": "lookupScreenThreshold",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$ReferenceToEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.ReferenceToEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$ReferenceToEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.ReferenceToEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "entityId",
+          "lazy": false
+        },
+        {
+          "name": "stringEntityId",
+          "lazy": false
+        },
+        {
+          "name": "intEntityId",
+          "lazy": false
+        },
+        {
+          "name": "longEntityId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "entityId",
+          "lazy": false
+        },
+        {
+          "name": "stringEntityId",
+          "lazy": false
+        },
+        {
+          "name": "intEntityId",
+          "lazy": false
+        },
+        {
+          "name": "longEntityId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sys$ReferenceToEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.ReferenceToEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "entityId",
+          "lazy": false
+        },
+        {
+          "name": "stringEntityId",
+          "lazy": false
+        },
+        {
+          "name": "intEntityId",
+          "lazy": false
+        },
+        {
+          "name": "longEntityId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "entityId",
+          "lazy": false
+        },
+        {
+          "name": "stringEntityId",
+          "lazy": false
+        },
+        {
+          "name": "intEntityId",
+          "lazy": false
+        },
+        {
+          "name": "longEntityId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$BaseIdentityIdEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.BaseIdentityIdEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$BaseIdentityIdEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.BaseIdentityIdEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sys$BaseIdentityIdEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.BaseIdentityIdEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$EntityCollectionPropertyDiff",
+      "classFqn": "com.haulmont.cuba.core.entity.diff.EntityCollectionPropertyDiff",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$EntityCollectionPropertyDiff",
+      "classFqn": "com.haulmont.cuba.core.entity.diff.EntityCollectionPropertyDiff",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sys$EntityCollectionPropertyDiff",
+      "classFqn": "com.haulmont.cuba.core.entity.diff.EntityCollectionPropertyDiff",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$RememberMeToken",
+      "classFqn": "com.haulmont.cuba.security.entity.RememberMeToken",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$RememberMeToken",
+      "classFqn": "com.haulmont.cuba.security.entity.RememberMeToken",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "token",
+          "lazy": false
+        },
+        {
+          "name": "createTs",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "token",
+          "lazy": false
+        },
+        {
+          "name": "createTs",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sec$RememberMeToken",
+      "classFqn": "com.haulmont.cuba.security.entity.RememberMeToken",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "token",
+          "lazy": false
+        },
+        {
+          "name": "createTs",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "token",
+          "lazy": false
+        },
+        {
+          "name": "createTs",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$FtsConditionDescriptor",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.descriptor.FtsConditionDescriptor",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$FtsConditionDescriptor",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.descriptor.FtsConditionDescriptor",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sec$FtsConditionDescriptor",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.descriptor.FtsConditionDescriptor",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$FtsQueue",
+      "classFqn": "com.haulmont.cuba.core.entity.FtsQueue",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$FtsQueue",
+      "classFqn": "com.haulmont.cuba.core.entity.FtsQueue",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "entityId",
+          "lazy": false
+        },
+        {
+          "name": "stringEntityId",
+          "lazy": false
+        },
+        {
+          "name": "intEntityId",
+          "lazy": false
+        },
+        {
+          "name": "longEntityId",
+          "lazy": false
+        },
+        {
+          "name": "entityName",
+          "lazy": false
+        },
+        {
+          "name": "changeType",
+          "lazy": false
+        },
+        {
+          "name": "sourceHost",
+          "lazy": false
+        },
+        {
+          "name": "indexingHost",
+          "lazy": false
+        },
+        {
+          "name": "fake",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "entityId",
+          "lazy": false
+        },
+        {
+          "name": "stringEntityId",
+          "lazy": false
+        },
+        {
+          "name": "intEntityId",
+          "lazy": false
+        },
+        {
+          "name": "longEntityId",
+          "lazy": false
+        },
+        {
+          "name": "entityName",
+          "lazy": false
+        },
+        {
+          "name": "changeType",
+          "lazy": false
+        },
+        {
+          "name": "sourceHost",
+          "lazy": false
+        },
+        {
+          "name": "indexingHost",
+          "lazy": false
+        },
+        {
+          "name": "fake",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sys$FtsQueue",
+      "classFqn": "com.haulmont.cuba.core.entity.FtsQueue",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "entityId",
+          "lazy": false
+        },
+        {
+          "name": "stringEntityId",
+          "lazy": false
+        },
+        {
+          "name": "intEntityId",
+          "lazy": false
+        },
+        {
+          "name": "longEntityId",
+          "lazy": false
+        },
+        {
+          "name": "entityName",
+          "lazy": false
+        },
+        {
+          "name": "changeType",
+          "lazy": false
+        },
+        {
+          "name": "sourceHost",
+          "lazy": false
+        },
+        {
+          "name": "indexingHost",
+          "lazy": false
+        },
+        {
+          "name": "fake",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "entityId",
+          "lazy": false
+        },
+        {
+          "name": "stringEntityId",
+          "lazy": false
+        },
+        {
+          "name": "intEntityId",
+          "lazy": false
+        },
+        {
+          "name": "longEntityId",
+          "lazy": false
+        },
+        {
+          "name": "entityName",
+          "lazy": false
+        },
+        {
+          "name": "changeType",
+          "lazy": false
+        },
+        {
+          "name": "sourceHost",
+          "lazy": false
+        },
+        {
+          "name": "indexingHost",
+          "lazy": false
+        },
+        {
+          "name": "fake",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$CategoryAttributeValue",
+      "classFqn": "com.haulmont.cuba.core.entity.CategoryAttributeValue",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$CategoryAttributeValue",
+      "classFqn": "com.haulmont.cuba.core.entity.CategoryAttributeValue",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "code",
+          "lazy": false
+        },
+        {
+          "name": "stringValue",
+          "lazy": false
+        },
+        {
+          "name": "intValue",
+          "lazy": false
+        },
+        {
+          "name": "doubleValue",
+          "lazy": false
+        },
+        {
+          "name": "decimalValue",
+          "lazy": false
+        },
+        {
+          "name": "booleanValue",
+          "lazy": false
+        },
+        {
+          "name": "dateValue",
+          "lazy": false
+        },
+        {
+          "name": "dateWithoutTimeValue",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "code",
+          "lazy": false
+        },
+        {
+          "name": "stringValue",
+          "lazy": false
+        },
+        {
+          "name": "intValue",
+          "lazy": false
+        },
+        {
+          "name": "doubleValue",
+          "lazy": false
+        },
+        {
+          "name": "decimalValue",
+          "lazy": false
+        },
+        {
+          "name": "booleanValue",
+          "lazy": false
+        },
+        {
+          "name": "dateValue",
+          "lazy": false
+        },
+        {
+          "name": "dateWithoutTimeValue",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sys$CategoryAttributeValue",
+      "classFqn": "com.haulmont.cuba.core.entity.CategoryAttributeValue",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "code",
+          "lazy": false
+        },
+        {
+          "name": "stringValue",
+          "lazy": false
+        },
+        {
+          "name": "intValue",
+          "lazy": false
+        },
+        {
+          "name": "doubleValue",
+          "lazy": false
+        },
+        {
+          "name": "decimalValue",
+          "lazy": false
+        },
+        {
+          "name": "booleanValue",
+          "lazy": false
+        },
+        {
+          "name": "dateValue",
+          "lazy": false
+        },
+        {
+          "name": "dateWithoutTimeValue",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "code",
+          "lazy": false
+        },
+        {
+          "name": "stringValue",
+          "lazy": false
+        },
+        {
+          "name": "intValue",
+          "lazy": false
+        },
+        {
+          "name": "doubleValue",
+          "lazy": false
+        },
+        {
+          "name": "decimalValue",
+          "lazy": false
+        },
+        {
+          "name": "booleanValue",
+          "lazy": false
+        },
+        {
+          "name": "dateValue",
+          "lazy": false
+        },
+        {
+          "name": "dateWithoutTimeValue",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "categoryAttributeValue",
+      "entity": "sys$CategoryAttributeValue",
+      "classFqn": "com.haulmont.cuba.core.entity.CategoryAttributeValue",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "categoryAttribute",
+          "entity": "sys$CategoryAttribute",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "code",
+          "lazy": false
+        },
+        {
+          "name": "stringValue",
+          "lazy": false
+        },
+        {
+          "name": "intValue",
+          "lazy": false
+        },
+        {
+          "name": "doubleValue",
+          "lazy": false
+        },
+        {
+          "name": "decimalValue",
+          "lazy": false
+        },
+        {
+          "name": "booleanValue",
+          "lazy": false
+        },
+        {
+          "name": "dateValue",
+          "lazy": false
+        },
+        {
+          "name": "dateWithoutTimeValue",
+          "lazy": false
+        },
+        {
+          "name": "categoryAttribute",
+          "entity": "sys$CategoryAttribute",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$OperationTarget",
+      "classFqn": "com.haulmont.cuba.gui.app.security.entity.OperationPermissionTarget",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$OperationTarget",
+      "classFqn": "com.haulmont.cuba.gui.app.security.entity.OperationPermissionTarget",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sec$OperationTarget",
+      "classFqn": "com.haulmont.cuba.gui.app.security.entity.OperationPermissionTarget",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$Server",
+      "classFqn": "com.haulmont.cuba.core.entity.Server",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_local",
+      "entity": "sys$Server",
+      "classFqn": "com.haulmont.cuba.core.entity.Server",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "running",
+          "lazy": false
+        },
+        {
+          "name": "data",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "running",
+          "lazy": false
+        },
+        {
+          "name": "data",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sys$Server",
+      "classFqn": "com.haulmont.cuba.core.entity.Server",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "running",
+          "lazy": false
+        },
+        {
+          "name": "data",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "running",
+          "lazy": false
+        },
+        {
+          "name": "data",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$EmbeddableEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.EmbeddableEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$EmbeddableEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.EmbeddableEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sys$EmbeddableEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.EmbeddableEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$Filter",
+      "classFqn": "com.haulmont.cuba.security.entity.FilterEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_local",
+      "entity": "sec$Filter",
+      "classFqn": "com.haulmont.cuba.security.entity.FilterEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "componentId",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "code",
+          "lazy": false
+        },
+        {
+          "name": "xml",
+          "lazy": false
+        },
+        {
+          "name": "globalDefault",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "componentId",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "code",
+          "lazy": false
+        },
+        {
+          "name": "xml",
+          "lazy": false
+        },
+        {
+          "name": "globalDefault",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sec$Filter",
+      "classFqn": "com.haulmont.cuba.security.entity.FilterEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "componentId",
+          "lazy": false
+        },
+        {
+          "name": "code",
+          "lazy": false
+        },
+        {
+          "name": "xml",
+          "lazy": false
+        },
+        {
+          "name": "globalDefault",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "componentId",
+          "lazy": false
+        },
+        {
+          "name": "code",
+          "lazy": false
+        },
+        {
+          "name": "xml",
+          "lazy": false
+        },
+        {
+          "name": "globalDefault",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "app",
+      "entity": "sec$Filter",
+      "classFqn": "com.haulmont.cuba.security.entity.FilterEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "componentId",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "code",
+          "lazy": false
+        },
+        {
+          "name": "xml",
+          "lazy": false
+        },
+        {
+          "name": "globalDefault",
+          "lazy": false
+        },
+        {
+          "name": "user",
+          "entity": "sec$User",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "componentId",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "code",
+          "lazy": false
+        },
+        {
+          "name": "xml",
+          "lazy": false
+        },
+        {
+          "name": "globalDefault",
+          "lazy": false
+        },
+        {
+          "name": "user",
+          "entity": "sec$User",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$SendingMessage",
+      "classFqn": "com.haulmont.cuba.core.entity.SendingMessage",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$SendingMessage",
+      "classFqn": "com.haulmont.cuba.core.entity.SendingMessage",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "address",
+          "lazy": false
+        },
+        {
+          "name": "from",
+          "lazy": false
+        },
+        {
+          "name": "cc",
+          "lazy": false
+        },
+        {
+          "name": "bcc",
+          "lazy": false
+        },
+        {
+          "name": "caption",
+          "lazy": false
+        },
+        {
+          "name": "contentText",
+          "lazy": false
+        },
+        {
+          "name": "status",
+          "lazy": false
+        },
+        {
+          "name": "dateSent",
+          "lazy": false
+        },
+        {
+          "name": "attachmentsName",
+          "lazy": false
+        },
+        {
+          "name": "deadline",
+          "lazy": false
+        },
+        {
+          "name": "attemptsCount",
+          "lazy": false
+        },
+        {
+          "name": "attemptsMade",
+          "lazy": false
+        },
+        {
+          "name": "headers",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "bodyContentType",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "address",
+          "lazy": false
+        },
+        {
+          "name": "from",
+          "lazy": false
+        },
+        {
+          "name": "cc",
+          "lazy": false
+        },
+        {
+          "name": "bcc",
+          "lazy": false
+        },
+        {
+          "name": "caption",
+          "lazy": false
+        },
+        {
+          "name": "contentText",
+          "lazy": false
+        },
+        {
+          "name": "status",
+          "lazy": false
+        },
+        {
+          "name": "dateSent",
+          "lazy": false
+        },
+        {
+          "name": "attachmentsName",
+          "lazy": false
+        },
+        {
+          "name": "deadline",
+          "lazy": false
+        },
+        {
+          "name": "attemptsCount",
+          "lazy": false
+        },
+        {
+          "name": "attemptsMade",
+          "lazy": false
+        },
+        {
+          "name": "headers",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "bodyContentType",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sys$SendingMessage",
+      "classFqn": "com.haulmont.cuba.core.entity.SendingMessage",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "address",
+          "lazy": false
+        },
+        {
+          "name": "from",
+          "lazy": false
+        },
+        {
+          "name": "cc",
+          "lazy": false
+        },
+        {
+          "name": "bcc",
+          "lazy": false
+        },
+        {
+          "name": "caption",
+          "lazy": false
+        },
+        {
+          "name": "contentText",
+          "lazy": false
+        },
+        {
+          "name": "status",
+          "lazy": false
+        },
+        {
+          "name": "dateSent",
+          "lazy": false
+        },
+        {
+          "name": "attachmentsName",
+          "lazy": false
+        },
+        {
+          "name": "deadline",
+          "lazy": false
+        },
+        {
+          "name": "attemptsCount",
+          "lazy": false
+        },
+        {
+          "name": "attemptsMade",
+          "lazy": false
+        },
+        {
+          "name": "headers",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "bodyContentType",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "address",
+          "lazy": false
+        },
+        {
+          "name": "from",
+          "lazy": false
+        },
+        {
+          "name": "cc",
+          "lazy": false
+        },
+        {
+          "name": "bcc",
+          "lazy": false
+        },
+        {
+          "name": "caption",
+          "lazy": false
+        },
+        {
+          "name": "contentText",
+          "lazy": false
+        },
+        {
+          "name": "status",
+          "lazy": false
+        },
+        {
+          "name": "dateSent",
+          "lazy": false
+        },
+        {
+          "name": "attachmentsName",
+          "lazy": false
+        },
+        {
+          "name": "deadline",
+          "lazy": false
+        },
+        {
+          "name": "attemptsCount",
+          "lazy": false
+        },
+        {
+          "name": "attemptsMade",
+          "lazy": false
+        },
+        {
+          "name": "headers",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "bodyContentType",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "sendingMessage.browse",
+      "entity": "sys$SendingMessage",
+      "classFqn": "com.haulmont.cuba.core.entity.SendingMessage",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "address",
+          "lazy": false
+        },
+        {
+          "name": "cc",
+          "lazy": false
+        },
+        {
+          "name": "bcc",
+          "lazy": false
+        },
+        {
+          "name": "attachmentsName",
+          "lazy": false
+        },
+        {
+          "name": "attemptsCount",
+          "lazy": false
+        },
+        {
+          "name": "attemptsMade",
+          "lazy": false
+        },
+        {
+          "name": "caption",
+          "lazy": false
+        },
+        {
+          "name": "dateSent",
+          "lazy": false
+        },
+        {
+          "name": "deadline",
+          "lazy": false
+        },
+        {
+          "name": "from",
+          "lazy": false
+        },
+        {
+          "name": "status",
+          "lazy": false
+        },
+        {
+          "name": "updateTs",
+          "lazy": false
+        },
+        {
+          "name": "bodyContentType",
+          "lazy": false
+        },
+        {
+          "name": "contentText",
+          "lazy": false
+        },
+        {
+          "name": "contentTextFile",
+          "entity": "sys$FileDescriptor",
+          "lazy": false
+        },
+        {
+          "name": "headers",
+          "lazy": false
+        },
+        {
+          "name": "attachments",
+          "entity": "sys$SendingAttachment",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "address",
+          "lazy": false
+        },
+        {
+          "name": "cc",
+          "lazy": false
+        },
+        {
+          "name": "bcc",
+          "lazy": false
+        },
+        {
+          "name": "attachmentsName",
+          "lazy": false
+        },
+        {
+          "name": "attemptsCount",
+          "lazy": false
+        },
+        {
+          "name": "attemptsMade",
+          "lazy": false
+        },
+        {
+          "name": "caption",
+          "lazy": false
+        },
+        {
+          "name": "dateSent",
+          "lazy": false
+        },
+        {
+          "name": "deadline",
+          "lazy": false
+        },
+        {
+          "name": "from",
+          "lazy": false
+        },
+        {
+          "name": "status",
+          "lazy": false
+        },
+        {
+          "name": "updateTs",
+          "lazy": false
+        },
+        {
+          "name": "bodyContentType",
+          "lazy": false
+        },
+        {
+          "name": "contentText",
+          "lazy": false
+        },
+        {
+          "name": "contentTextFile",
+          "entity": "sys$FileDescriptor",
+          "lazy": false
+        },
+        {
+          "name": "headers",
+          "lazy": false
+        },
+        {
+          "name": "attachments",
+          "entity": "sys$SendingAttachment",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "sendingMessage.loadFromQueue",
+      "entity": "sys$SendingMessage",
+      "classFqn": "com.haulmont.cuba.core.entity.SendingMessage",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": true,
+      "properties": [
+        {
+          "name": "attachments",
+          "entity": "sys$SendingAttachment",
+          "lazy": false
+        },
+        {
+          "name": "contentTextFile",
+          "entity": "sys$FileDescriptor",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "id",
+          "lazy": false
+        },
+        {
+          "name": "version",
+          "lazy": false
+        },
+        {
+          "name": "createTs",
+          "lazy": false
+        },
+        {
+          "name": "createdBy",
+          "lazy": false
+        },
+        {
+          "name": "updateTs",
+          "lazy": false
+        },
+        {
+          "name": "updatedBy",
+          "lazy": false
+        },
+        {
+          "name": "deleteTs",
+          "lazy": false
+        },
+        {
+          "name": "deletedBy",
+          "lazy": false
+        },
+        {
+          "name": "address",
+          "lazy": false
+        },
+        {
+          "name": "from",
+          "lazy": false
+        },
+        {
+          "name": "cc",
+          "lazy": false
+        },
+        {
+          "name": "bcc",
+          "lazy": false
+        },
+        {
+          "name": "caption",
+          "lazy": false
+        },
+        {
+          "name": "contentText",
+          "lazy": false
+        },
+        {
+          "name": "status",
+          "lazy": false
+        },
+        {
+          "name": "dateSent",
+          "lazy": false
+        },
+        {
+          "name": "attachmentsName",
+          "lazy": false
+        },
+        {
+          "name": "deadline",
+          "lazy": false
+        },
+        {
+          "name": "attemptsCount",
+          "lazy": false
+        },
+        {
+          "name": "attemptsMade",
+          "lazy": false
+        },
+        {
+          "name": "headers",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "bodyContentType",
+          "lazy": false
+        },
+        {
+          "name": "attachments",
+          "entity": "sys$SendingAttachment",
+          "lazy": false
+        },
+        {
+          "name": "contentTextFile",
+          "entity": "sys$FileDescriptor",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "sendingMessage.loadContentText",
+      "entity": "sys$SendingMessage",
+      "classFqn": "com.haulmont.cuba.core.entity.SendingMessage",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "contentTextFile",
+          "entity": "sys$FileDescriptor",
+          "lazy": false
+        },
+        {
+          "name": "contentText",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "contentTextFile",
+          "entity": "sys$FileDescriptor",
+          "lazy": false
+        },
+        {
+          "name": "contentText",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "stat$PerformanceParameter",
+      "classFqn": "com.haulmont.cuba.web.app.ui.statistics.PerformanceParameter",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "stat$PerformanceParameter",
+      "classFqn": "com.haulmont.cuba.web.app.ui.statistics.PerformanceParameter",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "stat$PerformanceParameter",
+      "classFqn": "com.haulmont.cuba.web.app.ui.statistics.PerformanceParameter",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$ScreenHistory",
+      "classFqn": "com.haulmont.cuba.security.entity.ScreenHistoryEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$ScreenHistory",
+      "classFqn": "com.haulmont.cuba.security.entity.ScreenHistoryEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "caption",
+          "lazy": false
+        },
+        {
+          "name": "url",
+          "lazy": false
+        },
+        {
+          "name": "displayUser",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "caption",
+          "lazy": false
+        },
+        {
+          "name": "url",
+          "lazy": false
+        },
+        {
+          "name": "displayUser",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sec$ScreenHistory",
+      "classFqn": "com.haulmont.cuba.security.entity.ScreenHistoryEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "caption",
+          "lazy": false
+        },
+        {
+          "name": "url",
+          "lazy": false
+        },
+        {
+          "name": "displayUser",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "caption",
+          "lazy": false
+        },
+        {
+          "name": "url",
+          "lazy": false
+        },
+        {
+          "name": "displayUser",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "browse",
+      "entity": "sec$ScreenHistory",
+      "classFqn": "com.haulmont.cuba.security.entity.ScreenHistoryEntity",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "user",
+          "entity": "sec$User",
+          "lazy": false
+        },
+        {
+          "name": "substitutedUser",
+          "entity": "sec$User",
+          "lazy": false
+        },
+        {
+          "name": "createTs",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "caption",
+          "lazy": false
+        },
+        {
+          "name": "url",
+          "lazy": false
+        },
+        {
+          "name": "displayUser",
+          "lazy": false
+        },
+        {
+          "name": "user",
+          "entity": "sec$User",
+          "lazy": false
+        },
+        {
+          "name": "substitutedUser",
+          "entity": "sec$User",
+          "lazy": false
+        },
+        {
+          "name": "createTs",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "jmxcontrol$ManagedBeanOperationParameter",
+      "classFqn": "com.haulmont.cuba.web.jmx.entity.ManagedBeanOperationParameter",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "jmxcontrol$ManagedBeanOperationParameter",
+      "classFqn": "com.haulmont.cuba.web.jmx.entity.ManagedBeanOperationParameter",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "jmxcontrol$ManagedBeanOperationParameter",
+      "classFqn": "com.haulmont.cuba.web.jmx.entity.ManagedBeanOperationParameter",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$BaseGenericIdEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.BaseGenericIdEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$BaseGenericIdEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.BaseGenericIdEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sys$BaseGenericIdEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.BaseGenericIdEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$AbstractCondition",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.condition.AbstractCondition",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$AbstractCondition",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.condition.AbstractCondition",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sec$AbstractCondition",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.condition.AbstractCondition",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$EntityLog",
+      "classFqn": "com.haulmont.cuba.security.entity.EntityLogItem",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$EntityLog",
+      "classFqn": "com.haulmont.cuba.security.entity.EntityLogItem",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "eventTs",
+          "lazy": false
+        },
+        {
+          "name": "type",
+          "lazy": false
+        },
+        {
+          "name": "entity",
+          "lazy": false
+        },
+        {
+          "name": "entityInstanceName",
+          "lazy": false
+        },
+        {
+          "name": "changes",
+          "lazy": false
+        },
+        {
+          "name": "displayedEntityName",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "eventTs",
+          "lazy": false
+        },
+        {
+          "name": "type",
+          "lazy": false
+        },
+        {
+          "name": "entity",
+          "lazy": false
+        },
+        {
+          "name": "entityInstanceName",
+          "lazy": false
+        },
+        {
+          "name": "changes",
+          "lazy": false
+        },
+        {
+          "name": "displayedEntityName",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sec$EntityLog",
+      "classFqn": "com.haulmont.cuba.security.entity.EntityLogItem",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "eventTs",
+          "lazy": false
+        },
+        {
+          "name": "type",
+          "lazy": false
+        },
+        {
+          "name": "entity",
+          "lazy": false
+        },
+        {
+          "name": "entityInstanceName",
+          "lazy": false
+        },
+        {
+          "name": "changes",
+          "lazy": false
+        },
+        {
+          "name": "displayedEntityName",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "eventTs",
+          "lazy": false
+        },
+        {
+          "name": "type",
+          "lazy": false
+        },
+        {
+          "name": "entity",
+          "lazy": false
+        },
+        {
+          "name": "entityInstanceName",
+          "lazy": false
+        },
+        {
+          "name": "changes",
+          "lazy": false
+        },
+        {
+          "name": "displayedEntityName",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "logView",
+      "entity": "sec$EntityLog",
+      "classFqn": "com.haulmont.cuba.security.entity.EntityLogItem",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "user",
+          "entity": "sec$User",
+          "lazy": false
+        },
+        {
+          "name": "entityRef",
+          "entity": "sys$ReferenceToEntity",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "eventTs",
+          "lazy": false
+        },
+        {
+          "name": "type",
+          "lazy": false
+        },
+        {
+          "name": "entity",
+          "lazy": false
+        },
+        {
+          "name": "entityInstanceName",
+          "lazy": false
+        },
+        {
+          "name": "changes",
+          "lazy": false
+        },
+        {
+          "name": "displayedEntityName",
+          "lazy": false
+        },
+        {
+          "name": "user",
+          "entity": "sec$User",
+          "lazy": false
+        },
+        {
+          "name": "entityRef",
+          "entity": "sys$ReferenceToEntity",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$Presentation",
+      "classFqn": "com.haulmont.cuba.security.entity.Presentation",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_local",
+      "entity": "sec$Presentation",
+      "classFqn": "com.haulmont.cuba.security.entity.Presentation",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "componentId",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "xml",
+          "lazy": false
+        },
+        {
+          "name": "autoSave",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "componentId",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "xml",
+          "lazy": false
+        },
+        {
+          "name": "autoSave",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sec$Presentation",
+      "classFqn": "com.haulmont.cuba.security.entity.Presentation",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "componentId",
+          "lazy": false
+        },
+        {
+          "name": "xml",
+          "lazy": false
+        },
+        {
+          "name": "autoSave",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "componentId",
+          "lazy": false
+        },
+        {
+          "name": "xml",
+          "lazy": false
+        },
+        {
+          "name": "autoSave",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "app",
+      "entity": "sec$Presentation",
+      "classFqn": "com.haulmont.cuba.security.entity.Presentation",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "componentId",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "xml",
+          "lazy": false
+        },
+        {
+          "name": "user",
+          "entity": "sec$User",
+          "lazy": false
+        },
+        {
+          "name": "autoSave",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "componentId",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "xml",
+          "lazy": false
+        },
+        {
+          "name": "user",
+          "entity": "sec$User",
+          "lazy": false
+        },
+        {
+          "name": "autoSave",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$User",
+      "classFqn": "com.haulmont.cuba.security.entity.User",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "login",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "login",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_local",
+      "entity": "sec$User",
+      "classFqn": "com.haulmont.cuba.security.entity.User",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "login",
+          "lazy": false
+        },
+        {
+          "name": "loginLowerCase",
+          "lazy": false
+        },
+        {
+          "name": "password",
+          "lazy": false
+        },
+        {
+          "name": "passwordEncryption",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "firstName",
+          "lazy": false
+        },
+        {
+          "name": "lastName",
+          "lazy": false
+        },
+        {
+          "name": "middleName",
+          "lazy": false
+        },
+        {
+          "name": "position",
+          "lazy": false
+        },
+        {
+          "name": "email",
+          "lazy": false
+        },
+        {
+          "name": "language",
+          "lazy": false
+        },
+        {
+          "name": "timeZone",
+          "lazy": false
+        },
+        {
+          "name": "timeZoneAuto",
+          "lazy": false
+        },
+        {
+          "name": "active",
+          "lazy": false
+        },
+        {
+          "name": "changePasswordAtNextLogon",
+          "lazy": false
+        },
+        {
+          "name": "groupNames",
+          "lazy": false
+        },
+        {
+          "name": "ipMask",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "login",
+          "lazy": false
+        },
+        {
+          "name": "loginLowerCase",
+          "lazy": false
+        },
+        {
+          "name": "password",
+          "lazy": false
+        },
+        {
+          "name": "passwordEncryption",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "firstName",
+          "lazy": false
+        },
+        {
+          "name": "lastName",
+          "lazy": false
+        },
+        {
+          "name": "middleName",
+          "lazy": false
+        },
+        {
+          "name": "position",
+          "lazy": false
+        },
+        {
+          "name": "email",
+          "lazy": false
+        },
+        {
+          "name": "language",
+          "lazy": false
+        },
+        {
+          "name": "timeZone",
+          "lazy": false
+        },
+        {
+          "name": "timeZoneAuto",
+          "lazy": false
+        },
+        {
+          "name": "active",
+          "lazy": false
+        },
+        {
+          "name": "changePasswordAtNextLogon",
+          "lazy": false
+        },
+        {
+          "name": "groupNames",
+          "lazy": false
+        },
+        {
+          "name": "ipMask",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sec$User",
+      "classFqn": "com.haulmont.cuba.security.entity.User",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "login",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "loginLowerCase",
+          "lazy": false
+        },
+        {
+          "name": "password",
+          "lazy": false
+        },
+        {
+          "name": "passwordEncryption",
+          "lazy": false
+        },
+        {
+          "name": "firstName",
+          "lazy": false
+        },
+        {
+          "name": "lastName",
+          "lazy": false
+        },
+        {
+          "name": "middleName",
+          "lazy": false
+        },
+        {
+          "name": "position",
+          "lazy": false
+        },
+        {
+          "name": "email",
+          "lazy": false
+        },
+        {
+          "name": "language",
+          "lazy": false
+        },
+        {
+          "name": "timeZone",
+          "lazy": false
+        },
+        {
+          "name": "timeZoneAuto",
+          "lazy": false
+        },
+        {
+          "name": "active",
+          "lazy": false
+        },
+        {
+          "name": "changePasswordAtNextLogon",
+          "lazy": false
+        },
+        {
+          "name": "groupNames",
+          "lazy": false
+        },
+        {
+          "name": "ipMask",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "login",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "loginLowerCase",
+          "lazy": false
+        },
+        {
+          "name": "password",
+          "lazy": false
+        },
+        {
+          "name": "passwordEncryption",
+          "lazy": false
+        },
+        {
+          "name": "firstName",
+          "lazy": false
+        },
+        {
+          "name": "lastName",
+          "lazy": false
+        },
+        {
+          "name": "middleName",
+          "lazy": false
+        },
+        {
+          "name": "position",
+          "lazy": false
+        },
+        {
+          "name": "email",
+          "lazy": false
+        },
+        {
+          "name": "language",
+          "lazy": false
+        },
+        {
+          "name": "timeZone",
+          "lazy": false
+        },
+        {
+          "name": "timeZoneAuto",
+          "lazy": false
+        },
+        {
+          "name": "active",
+          "lazy": false
+        },
+        {
+          "name": "changePasswordAtNextLogon",
+          "lazy": false
+        },
+        {
+          "name": "groupNames",
+          "lazy": false
+        },
+        {
+          "name": "ipMask",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "app",
+      "entity": "sec$User",
+      "classFqn": "com.haulmont.cuba.security.entity.User",
+      "parentName": "_minimal",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": [
+        {
+          "name": "login",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "user.edit",
+      "entity": "sec$User",
+      "classFqn": "com.haulmont.cuba.security.entity.User",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "group",
+          "entity": "sec$Group",
+          "lazy": false
+        },
+        {
+          "name": "userRoles",
+          "entity": "sec$UserRole",
+          "lazy": false
+        },
+        {
+          "name": "substitutions",
+          "entity": "sec$UserSubstitution",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "login",
+          "lazy": false
+        },
+        {
+          "name": "loginLowerCase",
+          "lazy": false
+        },
+        {
+          "name": "password",
+          "lazy": false
+        },
+        {
+          "name": "passwordEncryption",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "firstName",
+          "lazy": false
+        },
+        {
+          "name": "lastName",
+          "lazy": false
+        },
+        {
+          "name": "middleName",
+          "lazy": false
+        },
+        {
+          "name": "position",
+          "lazy": false
+        },
+        {
+          "name": "email",
+          "lazy": false
+        },
+        {
+          "name": "language",
+          "lazy": false
+        },
+        {
+          "name": "timeZone",
+          "lazy": false
+        },
+        {
+          "name": "timeZoneAuto",
+          "lazy": false
+        },
+        {
+          "name": "active",
+          "lazy": false
+        },
+        {
+          "name": "changePasswordAtNextLogon",
+          "lazy": false
+        },
+        {
+          "name": "groupNames",
+          "lazy": false
+        },
+        {
+          "name": "ipMask",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "group",
+          "entity": "sec$Group",
+          "lazy": false
+        },
+        {
+          "name": "userRoles",
+          "entity": "sec$UserRole",
+          "lazy": false
+        },
+        {
+          "name": "substitutions",
+          "entity": "sec$UserSubstitution",
+          "lazy": false
+        },
+        {
+          "name": "phone",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "user.browse",
+      "entity": "sec$User",
+      "classFqn": "com.haulmont.cuba.security.entity.User",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": true,
+      "properties": [
+        {
+          "name": "group",
+          "entity": "sec$Group",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "id",
+          "lazy": false
+        },
+        {
+          "name": "version",
+          "lazy": false
+        },
+        {
+          "name": "createTs",
+          "lazy": false
+        },
+        {
+          "name": "createdBy",
+          "lazy": false
+        },
+        {
+          "name": "updateTs",
+          "lazy": false
+        },
+        {
+          "name": "updatedBy",
+          "lazy": false
+        },
+        {
+          "name": "deleteTs",
+          "lazy": false
+        },
+        {
+          "name": "deletedBy",
+          "lazy": false
+        },
+        {
+          "name": "login",
+          "lazy": false
+        },
+        {
+          "name": "loginLowerCase",
+          "lazy": false
+        },
+        {
+          "name": "password",
+          "lazy": false
+        },
+        {
+          "name": "passwordEncryption",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "firstName",
+          "lazy": false
+        },
+        {
+          "name": "lastName",
+          "lazy": false
+        },
+        {
+          "name": "middleName",
+          "lazy": false
+        },
+        {
+          "name": "position",
+          "lazy": false
+        },
+        {
+          "name": "email",
+          "lazy": false
+        },
+        {
+          "name": "language",
+          "lazy": false
+        },
+        {
+          "name": "timeZone",
+          "lazy": false
+        },
+        {
+          "name": "timeZoneAuto",
+          "lazy": false
+        },
+        {
+          "name": "active",
+          "lazy": false
+        },
+        {
+          "name": "changePasswordAtNextLogon",
+          "lazy": false
+        },
+        {
+          "name": "groupNames",
+          "lazy": false
+        },
+        {
+          "name": "ipMask",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "group",
+          "entity": "sec$Group",
+          "lazy": false
+        },
+        {
+          "name": "phone",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "user.copySettings",
+      "entity": "sec$User",
+      "classFqn": "com.haulmont.cuba.security.entity.User",
+      "parentName": "_minimal",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "login",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "login",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "login",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "user.changepassw",
+      "entity": "sec$User",
+      "classFqn": "com.haulmont.cuba.security.entity.User",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "password",
+          "lazy": false
+        },
+        {
+          "name": "changePasswordAtNextLogon",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "password",
+          "lazy": false
+        },
+        {
+          "name": "changePasswordAtNextLogon",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "user.resetPassword",
+      "entity": "sec$User",
+      "classFqn": "com.haulmont.cuba.security.entity.User",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": [
+        {
+          "name": "login",
+          "lazy": false
+        },
+        {
+          "name": "loginLowerCase",
+          "lazy": false
+        },
+        {
+          "name": "password",
+          "lazy": false
+        },
+        {
+          "name": "passwordEncryption",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "firstName",
+          "lazy": false
+        },
+        {
+          "name": "lastName",
+          "lazy": false
+        },
+        {
+          "name": "middleName",
+          "lazy": false
+        },
+        {
+          "name": "position",
+          "lazy": false
+        },
+        {
+          "name": "email",
+          "lazy": false
+        },
+        {
+          "name": "language",
+          "lazy": false
+        },
+        {
+          "name": "timeZone",
+          "lazy": false
+        },
+        {
+          "name": "timeZoneAuto",
+          "lazy": false
+        },
+        {
+          "name": "active",
+          "lazy": false
+        },
+        {
+          "name": "changePasswordAtNextLogon",
+          "lazy": false
+        },
+        {
+          "name": "groupNames",
+          "lazy": false
+        },
+        {
+          "name": "ipMask",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "phone",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "user.locale",
+      "entity": "sec$User",
+      "classFqn": "com.haulmont.cuba.security.entity.User",
+      "parentName": "_minimal",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "language",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "login",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "language",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "user.check",
+      "entity": "sec$User",
+      "classFqn": "com.haulmont.cuba.security.entity.User",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "password",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "password",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "user.timeZone",
+      "entity": "sec$User",
+      "classFqn": "com.haulmont.cuba.security.entity.User",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "timeZone",
+          "lazy": false
+        },
+        {
+          "name": "timeZoneAuto",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "timeZone",
+          "lazy": false
+        },
+        {
+          "name": "timeZoneAuto",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "user.changePassword",
+      "entity": "sec$User",
+      "classFqn": "com.haulmont.cuba.security.entity.User",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "password",
+          "lazy": false
+        },
+        {
+          "name": "changePasswordAtNextLogon",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "password",
+          "lazy": false
+        },
+        {
+          "name": "changePasswordAtNextLogon",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "scheduling",
+      "entity": "sec$User",
+      "classFqn": "com.haulmont.cuba.security.entity.User",
+      "parentName": "_minimal",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": [
+        {
+          "name": "login",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "group.browse",
+      "entity": "sec$User",
+      "classFqn": "com.haulmont.cuba.security.entity.User",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "login",
+          "lazy": false
+        },
+        {
+          "name": "group",
+          "entity": "sec$Group",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "login",
+          "lazy": false
+        },
+        {
+          "name": "group",
+          "entity": "sec$Group",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "user.moveToGroup",
+      "entity": "sec$User",
+      "classFqn": "com.haulmont.cuba.security.entity.User",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "group",
+          "entity": "sec$Group",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "group",
+          "entity": "sec$Group",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$UserSetting",
+      "classFqn": "com.haulmont.cuba.security.entity.UserSetting",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$UserSetting",
+      "classFqn": "com.haulmont.cuba.security.entity.UserSetting",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "clientType",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "value",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "clientType",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "value",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sec$UserSetting",
+      "classFqn": "com.haulmont.cuba.security.entity.UserSetting",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "clientType",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "value",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "clientType",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "value",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "userSetting.value",
+      "entity": "sec$UserSetting",
+      "classFqn": "com.haulmont.cuba.security.entity.UserSetting",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "value",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "value",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$FileDescriptor",
+      "classFqn": "com.haulmont.cuba.core.entity.FileDescriptor",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "createDate",
+          "lazy": false
+        },
+        {
+          "name": "extension",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "createDate",
+          "lazy": false
+        },
+        {
+          "name": "extension",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_local",
+      "entity": "sys$FileDescriptor",
+      "classFqn": "com.haulmont.cuba.core.entity.FileDescriptor",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "extension",
+          "lazy": false
+        },
+        {
+          "name": "size",
+          "lazy": false
+        },
+        {
+          "name": "createDate",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "extension",
+          "lazy": false
+        },
+        {
+          "name": "size",
+          "lazy": false
+        },
+        {
+          "name": "createDate",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sys$FileDescriptor",
+      "classFqn": "com.haulmont.cuba.core.entity.FileDescriptor",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "createDate",
+          "lazy": false
+        },
+        {
+          "name": "extension",
+          "lazy": false
+        },
+        {
+          "name": "size",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "createDate",
+          "lazy": false
+        },
+        {
+          "name": "extension",
+          "lazy": false
+        },
+        {
+          "name": "size",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "browse",
+      "entity": "sys$FileDescriptor",
+      "classFqn": "com.haulmont.cuba.core.entity.FileDescriptor",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "extension",
+          "lazy": false
+        },
+        {
+          "name": "size",
+          "lazy": false
+        },
+        {
+          "name": "createDate",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "extension",
+          "lazy": false
+        },
+        {
+          "name": "size",
+          "lazy": false
+        },
+        {
+          "name": "createDate",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$StandardEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.StandardEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$StandardEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.StandardEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sys$StandardEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.StandardEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "jmxcontrol$ManagedBeanInfo",
+      "classFqn": "com.haulmont.cuba.web.jmx.entity.ManagedBeanInfo",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "jmxcontrol$ManagedBeanInfo",
+      "classFqn": "com.haulmont.cuba.web.jmx.entity.ManagedBeanInfo",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "jmxcontrol$ManagedBeanInfo",
+      "classFqn": "com.haulmont.cuba.web.jmx.entity.ManagedBeanInfo",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$SearchFolder",
+      "classFqn": "com.haulmont.cuba.security.entity.SearchFolder",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$SearchFolder",
+      "classFqn": "com.haulmont.cuba.security.entity.SearchFolder",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "isSet",
+          "lazy": false
+        },
+        {
+          "name": "entityType",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "sortOrder",
+          "lazy": false
+        },
+        {
+          "name": "tabName",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "filterComponentId",
+          "lazy": false
+        },
+        {
+          "name": "filterXml",
+          "lazy": false
+        },
+        {
+          "name": "applyDefault",
+          "lazy": false
+        },
+        {
+          "name": "locName",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "isSet",
+          "lazy": false
+        },
+        {
+          "name": "entityType",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "sortOrder",
+          "lazy": false
+        },
+        {
+          "name": "tabName",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "filterComponentId",
+          "lazy": false
+        },
+        {
+          "name": "filterXml",
+          "lazy": false
+        },
+        {
+          "name": "applyDefault",
+          "lazy": false
+        },
+        {
+          "name": "locName",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sec$SearchFolder",
+      "classFqn": "com.haulmont.cuba.security.entity.SearchFolder",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "isSet",
+          "lazy": false
+        },
+        {
+          "name": "entityType",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "sortOrder",
+          "lazy": false
+        },
+        {
+          "name": "tabName",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "filterComponentId",
+          "lazy": false
+        },
+        {
+          "name": "filterXml",
+          "lazy": false
+        },
+        {
+          "name": "applyDefault",
+          "lazy": false
+        },
+        {
+          "name": "locName",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "isSet",
+          "lazy": false
+        },
+        {
+          "name": "entityType",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "sortOrder",
+          "lazy": false
+        },
+        {
+          "name": "tabName",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "filterComponentId",
+          "lazy": false
+        },
+        {
+          "name": "filterXml",
+          "lazy": false
+        },
+        {
+          "name": "applyDefault",
+          "lazy": false
+        },
+        {
+          "name": "locName",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "searchFolders",
+      "entity": "sec$SearchFolder",
+      "classFqn": "com.haulmont.cuba.security.entity.SearchFolder",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": true,
+      "properties": [
+        {
+          "name": "user",
+          "entity": "sec$User",
+          "lazy": false
+        },
+        {
+          "name": "presentation",
+          "entity": "sec$Presentation",
+          "lazy": false
+        },
+        {
+          "name": "parent",
+          "entity": "sys$Folder",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "id",
+          "lazy": false
+        },
+        {
+          "name": "version",
+          "lazy": false
+        },
+        {
+          "name": "createTs",
+          "lazy": false
+        },
+        {
+          "name": "createdBy",
+          "lazy": false
+        },
+        {
+          "name": "updateTs",
+          "lazy": false
+        },
+        {
+          "name": "updatedBy",
+          "lazy": false
+        },
+        {
+          "name": "deleteTs",
+          "lazy": false
+        },
+        {
+          "name": "deletedBy",
+          "lazy": false
+        },
+        {
+          "name": "isSet",
+          "lazy": false
+        },
+        {
+          "name": "entityType",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "sortOrder",
+          "lazy": false
+        },
+        {
+          "name": "tabName",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "filterComponentId",
+          "lazy": false
+        },
+        {
+          "name": "filterXml",
+          "lazy": false
+        },
+        {
+          "name": "applyDefault",
+          "lazy": false
+        },
+        {
+          "name": "locName",
+          "lazy": false
+        },
+        {
+          "name": "user",
+          "entity": "sec$User",
+          "lazy": false
+        },
+        {
+          "name": "presentation",
+          "entity": "sec$Presentation",
+          "lazy": false
+        },
+        {
+          "name": "parent",
+          "entity": "sys$Folder",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$FtsCondition",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.condition.FtsCondition",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$FtsCondition",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.condition.FtsCondition",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sec$FtsCondition",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.condition.FtsCondition",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$EntityClassPropertyDiff",
+      "classFqn": "com.haulmont.cuba.core.entity.diff.EntityClassPropertyDiff",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$EntityClassPropertyDiff",
+      "classFqn": "com.haulmont.cuba.core.entity.diff.EntityClassPropertyDiff",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sys$EntityClassPropertyDiff",
+      "classFqn": "com.haulmont.cuba.core.entity.diff.EntityClassPropertyDiff",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$SendingAttachment",
+      "classFqn": "com.haulmont.cuba.core.entity.SendingAttachment",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$SendingAttachment",
+      "classFqn": "com.haulmont.cuba.core.entity.SendingAttachment",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "content",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "contentId",
+          "lazy": false
+        },
+        {
+          "name": "disposition",
+          "lazy": false
+        },
+        {
+          "name": "encoding",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "content",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "contentId",
+          "lazy": false
+        },
+        {
+          "name": "disposition",
+          "lazy": false
+        },
+        {
+          "name": "encoding",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sys$SendingAttachment",
+      "classFqn": "com.haulmont.cuba.core.entity.SendingAttachment",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "content",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "contentId",
+          "lazy": false
+        },
+        {
+          "name": "disposition",
+          "lazy": false
+        },
+        {
+          "name": "encoding",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "content",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "contentId",
+          "lazy": false
+        },
+        {
+          "name": "disposition",
+          "lazy": false
+        },
+        {
+          "name": "encoding",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "sendingAttachment.loadFromQueue",
+      "entity": "sys$SendingAttachment",
+      "classFqn": "com.haulmont.cuba.core.entity.SendingAttachment",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": true,
+      "properties": [
+        {
+          "name": "contentFile",
+          "entity": "sys$FileDescriptor",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "id",
+          "lazy": false
+        },
+        {
+          "name": "version",
+          "lazy": false
+        },
+        {
+          "name": "createTs",
+          "lazy": false
+        },
+        {
+          "name": "createdBy",
+          "lazy": false
+        },
+        {
+          "name": "updateTs",
+          "lazy": false
+        },
+        {
+          "name": "updatedBy",
+          "lazy": false
+        },
+        {
+          "name": "deleteTs",
+          "lazy": false
+        },
+        {
+          "name": "deletedBy",
+          "lazy": false
+        },
+        {
+          "name": "content",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "contentId",
+          "lazy": false
+        },
+        {
+          "name": "disposition",
+          "lazy": false
+        },
+        {
+          "name": "encoding",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "contentFile",
+          "entity": "sys$FileDescriptor",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "sendingAttachment.browse",
+      "entity": "sys$SendingAttachment",
+      "classFqn": "com.haulmont.cuba.core.entity.SendingAttachment",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "updateTs",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "content",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "contentId",
+          "lazy": false
+        },
+        {
+          "name": "disposition",
+          "lazy": false
+        },
+        {
+          "name": "encoding",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "updateTs",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$LoggedEntity",
+      "classFqn": "com.haulmont.cuba.security.entity.LoggedEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$LoggedEntity",
+      "classFqn": "com.haulmont.cuba.security.entity.LoggedEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "auto",
+          "lazy": false
+        },
+        {
+          "name": "manual",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "auto",
+          "lazy": false
+        },
+        {
+          "name": "manual",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sec$LoggedEntity",
+      "classFqn": "com.haulmont.cuba.security.entity.LoggedEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "auto",
+          "lazy": false
+        },
+        {
+          "name": "manual",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "auto",
+          "lazy": false
+        },
+        {
+          "name": "manual",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "loggedAttrs",
+      "entity": "sec$LoggedEntity",
+      "classFqn": "com.haulmont.cuba.security.entity.LoggedEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "attributes",
+          "entity": "sec$LoggedAttribute",
+          "lazy": false
+        },
+        {
+          "name": "auto",
+          "lazy": false
+        },
+        {
+          "name": "manual",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "attributes",
+          "entity": "sec$LoggedAttribute",
+          "lazy": false
+        },
+        {
+          "name": "auto",
+          "lazy": false
+        },
+        {
+          "name": "manual",
+          "lazy": false
+        },
+        {
+          "name": "name",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$BaseUuidEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.BaseUuidEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$BaseUuidEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.BaseUuidEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sys$BaseUuidEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.BaseUuidEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$CategoryAttributeConfiguration",
+      "classFqn": "com.haulmont.cuba.core.entity.CategoryAttributeConfiguration",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$CategoryAttributeConfiguration",
+      "classFqn": "com.haulmont.cuba.core.entity.CategoryAttributeConfiguration",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sys$CategoryAttributeConfiguration",
+      "classFqn": "com.haulmont.cuba.core.entity.CategoryAttributeConfiguration",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "jmxcontrol$ManagedBeanOperation",
+      "classFqn": "com.haulmont.cuba.web.jmx.entity.ManagedBeanOperation",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "jmxcontrol$ManagedBeanOperation",
+      "classFqn": "com.haulmont.cuba.web.jmx.entity.ManagedBeanOperation",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "jmxcontrol$ManagedBeanOperation",
+      "classFqn": "com.haulmont.cuba.web.jmx.entity.ManagedBeanOperation",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$LocalizedConstraintMessage",
+      "classFqn": "com.haulmont.cuba.security.entity.LocalizedConstraintMessage",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$LocalizedConstraintMessage",
+      "classFqn": "com.haulmont.cuba.security.entity.LocalizedConstraintMessage",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "entityName",
+          "lazy": false
+        },
+        {
+          "name": "operationType",
+          "lazy": false
+        },
+        {
+          "name": "values",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "entityName",
+          "lazy": false
+        },
+        {
+          "name": "operationType",
+          "lazy": false
+        },
+        {
+          "name": "values",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sec$LocalizedConstraintMessage",
+      "classFqn": "com.haulmont.cuba.security.entity.LocalizedConstraintMessage",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "entityName",
+          "lazy": false
+        },
+        {
+          "name": "operationType",
+          "lazy": false
+        },
+        {
+          "name": "values",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "entityName",
+          "lazy": false
+        },
+        {
+          "name": "operationType",
+          "lazy": false
+        },
+        {
+          "name": "values",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$ScheduledTask",
+      "classFqn": "com.haulmont.cuba.core.entity.ScheduledTask",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "beanName",
+          "lazy": false
+        },
+        {
+          "name": "methodName",
+          "lazy": false
+        },
+        {
+          "name": "className",
+          "lazy": false
+        },
+        {
+          "name": "scriptName",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "beanName",
+          "lazy": false
+        },
+        {
+          "name": "methodName",
+          "lazy": false
+        },
+        {
+          "name": "className",
+          "lazy": false
+        },
+        {
+          "name": "scriptName",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_local",
+      "entity": "sys$ScheduledTask",
+      "classFqn": "com.haulmont.cuba.core.entity.ScheduledTask",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "definedBy",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "beanName",
+          "lazy": false
+        },
+        {
+          "name": "methodName",
+          "lazy": false
+        },
+        {
+          "name": "className",
+          "lazy": false
+        },
+        {
+          "name": "scriptName",
+          "lazy": false
+        },
+        {
+          "name": "userName",
+          "lazy": false
+        },
+        {
+          "name": "singleton",
+          "lazy": false
+        },
+        {
+          "name": "active",
+          "lazy": false
+        },
+        {
+          "name": "period",
+          "lazy": false
+        },
+        {
+          "name": "timeout",
+          "lazy": false
+        },
+        {
+          "name": "startDate",
+          "lazy": false
+        },
+        {
+          "name": "cron",
+          "lazy": false
+        },
+        {
+          "name": "schedulingType",
+          "lazy": false
+        },
+        {
+          "name": "timeFrame",
+          "lazy": false
+        },
+        {
+          "name": "startDelay",
+          "lazy": false
+        },
+        {
+          "name": "permittedServers",
+          "lazy": false
+        },
+        {
+          "name": "logStart",
+          "lazy": false
+        },
+        {
+          "name": "logFinish",
+          "lazy": false
+        },
+        {
+          "name": "lastStartTime",
+          "lazy": false
+        },
+        {
+          "name": "lastStartServer",
+          "lazy": false
+        },
+        {
+          "name": "methodParamsXml",
+          "lazy": false
+        },
+        {
+          "name": "description",
+          "lazy": false
+        },
+        {
+          "name": "methodParametersString",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "definedBy",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "beanName",
+          "lazy": false
+        },
+        {
+          "name": "methodName",
+          "lazy": false
+        },
+        {
+          "name": "className",
+          "lazy": false
+        },
+        {
+          "name": "scriptName",
+          "lazy": false
+        },
+        {
+          "name": "userName",
+          "lazy": false
+        },
+        {
+          "name": "singleton",
+          "lazy": false
+        },
+        {
+          "name": "active",
+          "lazy": false
+        },
+        {
+          "name": "period",
+          "lazy": false
+        },
+        {
+          "name": "timeout",
+          "lazy": false
+        },
+        {
+          "name": "startDate",
+          "lazy": false
+        },
+        {
+          "name": "cron",
+          "lazy": false
+        },
+        {
+          "name": "schedulingType",
+          "lazy": false
+        },
+        {
+          "name": "timeFrame",
+          "lazy": false
+        },
+        {
+          "name": "startDelay",
+          "lazy": false
+        },
+        {
+          "name": "permittedServers",
+          "lazy": false
+        },
+        {
+          "name": "logStart",
+          "lazy": false
+        },
+        {
+          "name": "logFinish",
+          "lazy": false
+        },
+        {
+          "name": "lastStartTime",
+          "lazy": false
+        },
+        {
+          "name": "lastStartServer",
+          "lazy": false
+        },
+        {
+          "name": "methodParamsXml",
+          "lazy": false
+        },
+        {
+          "name": "description",
+          "lazy": false
+        },
+        {
+          "name": "methodParametersString",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sys$ScheduledTask",
+      "classFqn": "com.haulmont.cuba.core.entity.ScheduledTask",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "beanName",
+          "lazy": false
+        },
+        {
+          "name": "methodName",
+          "lazy": false
+        },
+        {
+          "name": "className",
+          "lazy": false
+        },
+        {
+          "name": "scriptName",
+          "lazy": false
+        },
+        {
+          "name": "definedBy",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "userName",
+          "lazy": false
+        },
+        {
+          "name": "singleton",
+          "lazy": false
+        },
+        {
+          "name": "active",
+          "lazy": false
+        },
+        {
+          "name": "period",
+          "lazy": false
+        },
+        {
+          "name": "timeout",
+          "lazy": false
+        },
+        {
+          "name": "startDate",
+          "lazy": false
+        },
+        {
+          "name": "cron",
+          "lazy": false
+        },
+        {
+          "name": "schedulingType",
+          "lazy": false
+        },
+        {
+          "name": "timeFrame",
+          "lazy": false
+        },
+        {
+          "name": "startDelay",
+          "lazy": false
+        },
+        {
+          "name": "permittedServers",
+          "lazy": false
+        },
+        {
+          "name": "logStart",
+          "lazy": false
+        },
+        {
+          "name": "logFinish",
+          "lazy": false
+        },
+        {
+          "name": "lastStartTime",
+          "lazy": false
+        },
+        {
+          "name": "lastStartServer",
+          "lazy": false
+        },
+        {
+          "name": "methodParamsXml",
+          "lazy": false
+        },
+        {
+          "name": "description",
+          "lazy": false
+        },
+        {
+          "name": "methodParametersString",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "beanName",
+          "lazy": false
+        },
+        {
+          "name": "methodName",
+          "lazy": false
+        },
+        {
+          "name": "className",
+          "lazy": false
+        },
+        {
+          "name": "scriptName",
+          "lazy": false
+        },
+        {
+          "name": "definedBy",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "userName",
+          "lazy": false
+        },
+        {
+          "name": "singleton",
+          "lazy": false
+        },
+        {
+          "name": "active",
+          "lazy": false
+        },
+        {
+          "name": "period",
+          "lazy": false
+        },
+        {
+          "name": "timeout",
+          "lazy": false
+        },
+        {
+          "name": "startDate",
+          "lazy": false
+        },
+        {
+          "name": "cron",
+          "lazy": false
+        },
+        {
+          "name": "schedulingType",
+          "lazy": false
+        },
+        {
+          "name": "timeFrame",
+          "lazy": false
+        },
+        {
+          "name": "startDelay",
+          "lazy": false
+        },
+        {
+          "name": "permittedServers",
+          "lazy": false
+        },
+        {
+          "name": "logStart",
+          "lazy": false
+        },
+        {
+          "name": "logFinish",
+          "lazy": false
+        },
+        {
+          "name": "lastStartTime",
+          "lazy": false
+        },
+        {
+          "name": "lastStartServer",
+          "lazy": false
+        },
+        {
+          "name": "methodParamsXml",
+          "lazy": false
+        },
+        {
+          "name": "description",
+          "lazy": false
+        },
+        {
+          "name": "methodParametersString",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$CategoryAttributeEnumValue",
+      "classFqn": "com.haulmont.cuba.core.entity.CategoryAttributeEnumValue",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$CategoryAttributeEnumValue",
+      "classFqn": "com.haulmont.cuba.core.entity.CategoryAttributeEnumValue",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sys$CategoryAttributeEnumValue",
+      "classFqn": "com.haulmont.cuba.core.entity.CategoryAttributeEnumValue",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$AbstractNotPersistentEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.AbstractNotPersistentEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$AbstractNotPersistentEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.AbstractNotPersistentEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sys$AbstractNotPersistentEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.AbstractNotPersistentEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "jmxcontrol$ManagedBeanAttribute",
+      "classFqn": "com.haulmont.cuba.web.jmx.entity.ManagedBeanAttribute",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "jmxcontrol$ManagedBeanAttribute",
+      "classFqn": "com.haulmont.cuba.web.jmx.entity.ManagedBeanAttribute",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "jmxcontrol$ManagedBeanAttribute",
+      "classFqn": "com.haulmont.cuba.web.jmx.entity.ManagedBeanAttribute",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$LockInfo",
+      "classFqn": "com.haulmont.cuba.core.global.LockInfo",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$LockInfo",
+      "classFqn": "com.haulmont.cuba.core.global.LockInfo",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sys$LockInfo",
+      "classFqn": "com.haulmont.cuba.core.global.LockInfo",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$BaseIntIdentityIdEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.BaseIntIdentityIdEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$BaseIntIdentityIdEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.BaseIntIdentityIdEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sys$BaseIntIdentityIdEntity",
+      "classFqn": "com.haulmont.cuba.core.entity.BaseIntIdentityIdEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$AttributeLocaleData",
+      "classFqn": "com.haulmont.cuba.core.entity.AttributeLocaleData",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "languageWithCode",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "languageWithCode",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_local",
+      "entity": "sys$AttributeLocaleData",
+      "classFqn": "com.haulmont.cuba.core.entity.AttributeLocaleData",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sys$AttributeLocaleData",
+      "classFqn": "com.haulmont.cuba.core.entity.AttributeLocaleData",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "languageWithCode",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "languageWithCode",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$UserSessionEntity",
+      "classFqn": "com.haulmont.cuba.security.entity.UserSessionEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$UserSessionEntity",
+      "classFqn": "com.haulmont.cuba.security.entity.UserSessionEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sec$UserSessionEntity",
+      "classFqn": "com.haulmont.cuba.security.entity.UserSessionEntity",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$Permission",
+      "classFqn": "com.haulmont.cuba.security.entity.Permission",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$Permission",
+      "classFqn": "com.haulmont.cuba.security.entity.Permission",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "type",
+          "lazy": false
+        },
+        {
+          "name": "target",
+          "lazy": false
+        },
+        {
+          "name": "value",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "type",
+          "lazy": false
+        },
+        {
+          "name": "target",
+          "lazy": false
+        },
+        {
+          "name": "value",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sec$Permission",
+      "classFqn": "com.haulmont.cuba.security.entity.Permission",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "type",
+          "lazy": false
+        },
+        {
+          "name": "target",
+          "lazy": false
+        },
+        {
+          "name": "value",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "type",
+          "lazy": false
+        },
+        {
+          "name": "target",
+          "lazy": false
+        },
+        {
+          "name": "value",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "role.edit",
+      "entity": "sec$Permission",
+      "classFqn": "com.haulmont.cuba.security.entity.Permission",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "type",
+          "lazy": false
+        },
+        {
+          "name": "target",
+          "lazy": false
+        },
+        {
+          "name": "value",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "type",
+          "lazy": false
+        },
+        {
+          "name": "target",
+          "lazy": false
+        },
+        {
+          "name": "value",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$MultipleTarget",
+      "classFqn": "com.haulmont.cuba.gui.app.security.entity.MultiplePermissionTarget",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$MultipleTarget",
+      "classFqn": "com.haulmont.cuba.gui.app.security.entity.MultiplePermissionTarget",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sec$MultipleTarget",
+      "classFqn": "com.haulmont.cuba.gui.app.security.entity.MultiplePermissionTarget",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$CustomConditionDescriptor",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.descriptor.CustomConditionDescriptor",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$CustomConditionDescriptor",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.descriptor.CustomConditionDescriptor",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sec$CustomConditionDescriptor",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.descriptor.CustomConditionDescriptor",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$Target",
+      "classFqn": "com.haulmont.cuba.gui.app.security.entity.BasicPermissionTarget",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$Target",
+      "classFqn": "com.haulmont.cuba.gui.app.security.entity.BasicPermissionTarget",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sec$Target",
+      "classFqn": "com.haulmont.cuba.gui.app.security.entity.BasicPermissionTarget",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$QueryResult",
+      "classFqn": "com.haulmont.cuba.core.entity.QueryResult",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$QueryResult",
+      "classFqn": "com.haulmont.cuba.core.entity.QueryResult",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "sessionId",
+          "lazy": false
+        },
+        {
+          "name": "queryKey",
+          "lazy": false
+        },
+        {
+          "name": "entityId",
+          "lazy": false
+        },
+        {
+          "name": "stringEntityId",
+          "lazy": false
+        },
+        {
+          "name": "intEntityId",
+          "lazy": false
+        },
+        {
+          "name": "longEntityId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "sessionId",
+          "lazy": false
+        },
+        {
+          "name": "queryKey",
+          "lazy": false
+        },
+        {
+          "name": "entityId",
+          "lazy": false
+        },
+        {
+          "name": "stringEntityId",
+          "lazy": false
+        },
+        {
+          "name": "intEntityId",
+          "lazy": false
+        },
+        {
+          "name": "longEntityId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sys$QueryResult",
+      "classFqn": "com.haulmont.cuba.core.entity.QueryResult",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "sessionId",
+          "lazy": false
+        },
+        {
+          "name": "queryKey",
+          "lazy": false
+        },
+        {
+          "name": "entityId",
+          "lazy": false
+        },
+        {
+          "name": "stringEntityId",
+          "lazy": false
+        },
+        {
+          "name": "intEntityId",
+          "lazy": false
+        },
+        {
+          "name": "longEntityId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "sessionId",
+          "lazy": false
+        },
+        {
+          "name": "queryKey",
+          "lazy": false
+        },
+        {
+          "name": "entityId",
+          "lazy": false
+        },
+        {
+          "name": "stringEntityId",
+          "lazy": false
+        },
+        {
+          "name": "intEntityId",
+          "lazy": false
+        },
+        {
+          "name": "longEntityId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$DynamicAttributesConditionCreator",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.descriptor.DynamicAttributesConditionCreator",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$DynamicAttributesConditionCreator",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.descriptor.DynamicAttributesConditionCreator",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sec$DynamicAttributesConditionCreator",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.descriptor.DynamicAttributesConditionCreator",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$DynamicAttributesCondition",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.condition.DynamicAttributesCondition",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$DynamicAttributesCondition",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.condition.DynamicAttributesCondition",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_base",
+      "entity": "sec$DynamicAttributesCondition",
+      "classFqn": "com.haulmont.cuba.gui.components.filter.condition.DynamicAttributesCondition",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$UserSubstitution",
+      "classFqn": "com.haulmont.cuba.security.entity.UserSubstitution",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$UserSubstitution",
+      "classFqn": "com.haulmont.cuba.security.entity.UserSubstitution",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "startDate",
+          "lazy": false
+        },
+        {
+          "name": "endDate",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "startDate",
+          "lazy": false
+        },
+        {
+          "name": "endDate",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sec$UserSubstitution",
+      "classFqn": "com.haulmont.cuba.security.entity.UserSubstitution",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "startDate",
+          "lazy": false
+        },
+        {
+          "name": "endDate",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "startDate",
+          "lazy": false
+        },
+        {
+          "name": "endDate",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "app",
+      "entity": "sec$UserSubstitution",
+      "classFqn": "com.haulmont.cuba.security.entity.UserSubstitution",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "substitutedUser",
+          "entity": "sec$User",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "substitutedUser",
+          "entity": "sec$User",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "user.edit",
+      "entity": "sec$UserSubstitution",
+      "classFqn": "com.haulmont.cuba.security.entity.UserSubstitution",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "substitutedUser",
+          "entity": "sec$User",
+          "lazy": false
+        },
+        {
+          "name": "startDate",
+          "lazy": false
+        },
+        {
+          "name": "endDate",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "substitutedUser",
+          "entity": "sec$User",
+          "lazy": false
+        },
+        {
+          "name": "startDate",
+          "lazy": false
+        },
+        {
+          "name": "endDate",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "usersubst.edit",
+      "entity": "sec$UserSubstitution",
+      "classFqn": "com.haulmont.cuba.security.entity.UserSubstitution",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "user",
+          "entity": "sec$User",
+          "lazy": false
+        },
+        {
+          "name": "substitutedUser",
+          "entity": "sec$User",
+          "lazy": false
+        },
+        {
+          "name": "startDate",
+          "lazy": false
+        },
+        {
+          "name": "endDate",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "user",
+          "entity": "sec$User",
+          "lazy": false
+        },
+        {
+          "name": "substitutedUser",
+          "entity": "sec$User",
+          "lazy": false
+        },
+        {
+          "name": "startDate",
+          "lazy": false
+        },
+        {
+          "name": "endDate",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$SessionLogEntry",
+      "classFqn": "com.haulmont.cuba.security.entity.SessionLogEntry",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$SessionLogEntry",
+      "classFqn": "com.haulmont.cuba.security.entity.SessionLogEntry",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "sessionId",
+          "lazy": false
+        },
+        {
+          "name": "userData",
+          "lazy": false
+        },
+        {
+          "name": "lastAction",
+          "lazy": false
+        },
+        {
+          "name": "clientInfo",
+          "lazy": false
+        },
+        {
+          "name": "address",
+          "lazy": false
+        },
+        {
+          "name": "startedTs",
+          "lazy": false
+        },
+        {
+          "name": "finishedTs",
+          "lazy": false
+        },
+        {
+          "name": "clientType",
+          "lazy": false
+        },
+        {
+          "name": "server",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "sessionId",
+          "lazy": false
+        },
+        {
+          "name": "userData",
+          "lazy": false
+        },
+        {
+          "name": "lastAction",
+          "lazy": false
+        },
+        {
+          "name": "clientInfo",
+          "lazy": false
+        },
+        {
+          "name": "address",
+          "lazy": false
+        },
+        {
+          "name": "startedTs",
+          "lazy": false
+        },
+        {
+          "name": "finishedTs",
+          "lazy": false
+        },
+        {
+          "name": "clientType",
+          "lazy": false
+        },
+        {
+          "name": "server",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sec$SessionLogEntry",
+      "classFqn": "com.haulmont.cuba.security.entity.SessionLogEntry",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "sessionId",
+          "lazy": false
+        },
+        {
+          "name": "userData",
+          "lazy": false
+        },
+        {
+          "name": "lastAction",
+          "lazy": false
+        },
+        {
+          "name": "clientInfo",
+          "lazy": false
+        },
+        {
+          "name": "address",
+          "lazy": false
+        },
+        {
+          "name": "startedTs",
+          "lazy": false
+        },
+        {
+          "name": "finishedTs",
+          "lazy": false
+        },
+        {
+          "name": "clientType",
+          "lazy": false
+        },
+        {
+          "name": "server",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "sessionId",
+          "lazy": false
+        },
+        {
+          "name": "userData",
+          "lazy": false
+        },
+        {
+          "name": "lastAction",
+          "lazy": false
+        },
+        {
+          "name": "clientInfo",
+          "lazy": false
+        },
+        {
+          "name": "address",
+          "lazy": false
+        },
+        {
+          "name": "startedTs",
+          "lazy": false
+        },
+        {
+          "name": "finishedTs",
+          "lazy": false
+        },
+        {
+          "name": "clientType",
+          "lazy": false
+        },
+        {
+          "name": "server",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "sessionLogEntry-view",
+      "entity": "sec$SessionLogEntry",
+      "classFqn": "com.haulmont.cuba.security.entity.SessionLogEntry",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "user",
+          "entity": "sec$User",
+          "lazy": false
+        },
+        {
+          "name": "substitutedUser",
+          "entity": "sec$User",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "sessionId",
+          "lazy": false
+        },
+        {
+          "name": "userData",
+          "lazy": false
+        },
+        {
+          "name": "lastAction",
+          "lazy": false
+        },
+        {
+          "name": "clientInfo",
+          "lazy": false
+        },
+        {
+          "name": "address",
+          "lazy": false
+        },
+        {
+          "name": "startedTs",
+          "lazy": false
+        },
+        {
+          "name": "finishedTs",
+          "lazy": false
+        },
+        {
+          "name": "clientType",
+          "lazy": false
+        },
+        {
+          "name": "server",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "user",
+          "entity": "sec$User",
+          "lazy": false
+        },
+        {
+          "name": "substitutedUser",
+          "entity": "sec$User",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$UserRole",
+      "classFqn": "com.haulmont.cuba.security.entity.UserRole",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$UserRole",
+      "classFqn": "com.haulmont.cuba.security.entity.UserRole",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "roleName",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "roleName",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sec$UserRole",
+      "classFqn": "com.haulmont.cuba.security.entity.UserRole",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "roleName",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "roleName",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "user.edit",
+      "entity": "sec$UserRole",
+      "classFqn": "com.haulmont.cuba.security.entity.UserRole",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "role",
+          "entity": "sec$Role",
+          "lazy": false
+        },
+        {
+          "name": "roleName",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "role",
+          "entity": "sec$Role",
+          "lazy": false
+        },
+        {
+          "name": "roleName",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "tmp.user.edit",
+      "entity": "sec$UserRole",
+      "classFqn": "com.haulmont.cuba.security.entity.UserRole",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "user",
+          "entity": "sec$User",
+          "lazy": false
+        },
+        {
+          "name": "role",
+          "entity": "sec$Role",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "user",
+          "entity": "sec$User",
+          "lazy": false
+        },
+        {
+          "name": "role",
+          "entity": "sec$Role",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sec$SessionAttribute",
+      "classFqn": "com.haulmont.cuba.security.entity.SessionAttribute",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sec$SessionAttribute",
+      "classFqn": "com.haulmont.cuba.security.entity.SessionAttribute",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "stringValue",
+          "lazy": false
+        },
+        {
+          "name": "datatype",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "datatypeCaption",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "stringValue",
+          "lazy": false
+        },
+        {
+          "name": "datatype",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "datatypeCaption",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sec$SessionAttribute",
+      "classFqn": "com.haulmont.cuba.security.entity.SessionAttribute",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "stringValue",
+          "lazy": false
+        },
+        {
+          "name": "datatype",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "datatypeCaption",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "stringValue",
+          "lazy": false
+        },
+        {
+          "name": "datatype",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "datatypeCaption",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "edit",
+      "entity": "sec$SessionAttribute",
+      "classFqn": "com.haulmont.cuba.security.entity.SessionAttribute",
+      "parentName": "_local",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "group",
+          "entity": "sec$Group",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "name",
+          "lazy": false
+        },
+        {
+          "name": "stringValue",
+          "lazy": false
+        },
+        {
+          "name": "datatype",
+          "lazy": false
+        },
+        {
+          "name": "sysTenantId",
+          "lazy": false
+        },
+        {
+          "name": "datatypeCaption",
+          "lazy": false
+        },
+        {
+          "name": "group",
+          "entity": "sec$Group",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$RefreshToken",
+      "classFqn": "com.haulmont.addon.restapi.entity.RefreshToken",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$RefreshToken",
+      "classFqn": "com.haulmont.addon.restapi.entity.RefreshToken",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "createTs",
+          "lazy": false
+        },
+        {
+          "name": "tokenValue",
+          "lazy": false
+        },
+        {
+          "name": "tokenBytes",
+          "lazy": false
+        },
+        {
+          "name": "authenticationBytes",
+          "lazy": false
+        },
+        {
+          "name": "expiry",
+          "lazy": false
+        },
+        {
+          "name": "userLogin",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "createTs",
+          "lazy": false
+        },
+        {
+          "name": "tokenValue",
+          "lazy": false
+        },
+        {
+          "name": "tokenBytes",
+          "lazy": false
+        },
+        {
+          "name": "authenticationBytes",
+          "lazy": false
+        },
+        {
+          "name": "expiry",
+          "lazy": false
+        },
+        {
+          "name": "userLogin",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sys$RefreshToken",
+      "classFqn": "com.haulmont.addon.restapi.entity.RefreshToken",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "createTs",
+          "lazy": false
+        },
+        {
+          "name": "tokenValue",
+          "lazy": false
+        },
+        {
+          "name": "tokenBytes",
+          "lazy": false
+        },
+        {
+          "name": "authenticationBytes",
+          "lazy": false
+        },
+        {
+          "name": "expiry",
+          "lazy": false
+        },
+        {
+          "name": "userLogin",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "createTs",
+          "lazy": false
+        },
+        {
+          "name": "tokenValue",
+          "lazy": false
+        },
+        {
+          "name": "tokenBytes",
+          "lazy": false
+        },
+        {
+          "name": "authenticationBytes",
+          "lazy": false
+        },
+        {
+          "name": "expiry",
+          "lazy": false
+        },
+        {
+          "name": "userLogin",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_minimal",
+      "entity": "sys$AccessToken",
+      "classFqn": "com.haulmont.addon.restapi.entity.AccessToken",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [],
+      "allProperties": []
+    },
+    {
+      "name": "_local",
+      "entity": "sys$AccessToken",
+      "classFqn": "com.haulmont.addon.restapi.entity.AccessToken",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "createTs",
+          "lazy": false
+        },
+        {
+          "name": "tokenValue",
+          "lazy": false
+        },
+        {
+          "name": "tokenBytes",
+          "lazy": false
+        },
+        {
+          "name": "authenticationKey",
+          "lazy": false
+        },
+        {
+          "name": "authenticationBytes",
+          "lazy": false
+        },
+        {
+          "name": "expiry",
+          "lazy": false
+        },
+        {
+          "name": "userLogin",
+          "lazy": false
+        },
+        {
+          "name": "locale",
+          "lazy": false
+        },
+        {
+          "name": "refreshTokenValue",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "createTs",
+          "lazy": false
+        },
+        {
+          "name": "tokenValue",
+          "lazy": false
+        },
+        {
+          "name": "tokenBytes",
+          "lazy": false
+        },
+        {
+          "name": "authenticationKey",
+          "lazy": false
+        },
+        {
+          "name": "authenticationBytes",
+          "lazy": false
+        },
+        {
+          "name": "expiry",
+          "lazy": false
+        },
+        {
+          "name": "userLogin",
+          "lazy": false
+        },
+        {
+          "name": "locale",
+          "lazy": false
+        },
+        {
+          "name": "refreshTokenValue",
+          "lazy": false
+        }
+      ]
+    },
+    {
+      "name": "_base",
+      "entity": "sys$AccessToken",
+      "classFqn": "com.haulmont.addon.restapi.entity.AccessToken",
+      "overwrite": false,
+      "systemProperties": false,
+      "properties": [
+        {
+          "name": "createTs",
+          "lazy": false
+        },
+        {
+          "name": "tokenValue",
+          "lazy": false
+        },
+        {
+          "name": "tokenBytes",
+          "lazy": false
+        },
+        {
+          "name": "authenticationKey",
+          "lazy": false
+        },
+        {
+          "name": "authenticationBytes",
+          "lazy": false
+        },
+        {
+          "name": "expiry",
+          "lazy": false
+        },
+        {
+          "name": "userLogin",
+          "lazy": false
+        },
+        {
+          "name": "locale",
+          "lazy": false
+        },
+        {
+          "name": "refreshTokenValue",
+          "lazy": false
+        }
+      ],
+      "allProperties": [
+        {
+          "name": "createTs",
+          "lazy": false
+        },
+        {
+          "name": "tokenValue",
+          "lazy": false
+        },
+        {
+          "name": "tokenBytes",
+          "lazy": false
+        },
+        {
+          "name": "authenticationKey",
+          "lazy": false
+        },
+        {
+          "name": "authenticationBytes",
+          "lazy": false
+        },
+        {
+          "name": "expiry",
+          "lazy": false
+        },
+        {
+          "name": "userLogin",
+          "lazy": false
+        },
+        {
+          "name": "locale",
+          "lazy": false
+        },
+        {
+          "name": "refreshTokenValue",
+          "lazy": false
+        }
+      ]
+    }
+  ],
+  "restQueries": [
+    {
+      "name": "allCars",
+      "jpql": "select c from scr$Car c",
+      "entity": "scr$Car",
+      "view": "_local",
+      "params": []
+    },
+    {
+      "name": "ecoCars",
+      "jpql": "select c from scr$Car c where c.ecoRank = 3",
+      "entity": "scr$Car",
+      "view": "_local",
+      "params": []
+    },
+    {
+      "name": "ecoCars",
+      "jpql": "select c from scr$Car c where c.ecoRank > :ecoRank",
+      "entity": "scr$Car",
+      "view": "_local",
+      "params": [
+        {
+          "name": "ecoRank",
+          "type": "java.lang.String"
+        }
+      ]
+    },
+    {
+      "name": "ecoCars",
+      "jpql": "select c from scr$Car c where c.ecoRank = 3 and c.model like :model",
+      "entity": "scr$Car",
+      "view": "_local",
+      "params": [
+        {
+          "name": "model",
+          "type": "java.lang.String"
+        }
+      ]
+    },
+    {
+      "name": "carsByType",
+      "jpql": "select c from scr$Car c where c.carType = :carType",
+      "entity": "scr$Car",
+      "view": "_local",
+      "params": [
+        {
+          "name": "carType",
+          "type": "java.lang.String"
+        }
+      ]
+    },
+    {
+      "name": "allCars",
+      "jpql": "select f from scr$FavoriteCar f where f.car = :car",
+      "entity": "scr$FavoriteCar",
+      "view": "_local",
+      "params": [
+        {
+          "name": "car",
+          "type": "com.company.scr.entity.Car"
+        }
+      ]
+    }
+  ],
+  "restServices": [
+    {
+      "name": "scr_FavoriteService",
+      "methods": [
+        {
+          "name": "refreshCache",
+          "restInvocationAllowed": true,
+          "params": []
+        },
+        {
+          "name": "addFavorite",
+          "restInvocationAllowed": true,
+          "params": [
+            {
+              "name": "car",
+              "type": "com.company.scr.entity.Car"
+            },
+            {
+              "name": "notes",
+              "type": "java.lang.String"
+            }
+          ]
+        },
+        {
+          "name": "getFavorites",
+          "restInvocationAllowed": true,
+          "params": []
+        },
+        {
+          "name": "addFavorite",
+          "restInvocationAllowed": true,
+          "params": [
+            {
+              "name": "favInfo",
+              "type": "com.company.scr.service.FavoriteService.FavInfo"
+            }
+          ]
+        },
+        {
+          "name": "addFavorite",
+          "restInvocationAllowed": true,
+          "params": [
+            {
+              "name": "carId",
+              "type": "java.util.UUID"
+            },
+            {
+              "name": "notes",
+              "type": "java.lang.String"
+            }
+          ]
+        },
+        {
+          "name": "getFavoritesByType",
+          "restInvocationAllowed": true,
+          "params": [
+            {
+              "name": "carType",
+              "type": "com.company.scr.entity.CarType"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/front-generator/src/test/fixtures/view-properties--association-o2o.json
+++ b/packages/front-generator/src/test/fixtures/view-properties--association-o2o.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "name",
+    "lazy": false
+  },
+  {
+    "name": "datatypesTestEntity",
+    "entity": "scr_DatatypesTestEntity",
+    "lazy": false
+  }
+]

--- a/packages/front-generator/src/test/fixtures/view-properties--datatypes-test-entity.json
+++ b/packages/front-generator/src/test/fixtures/view-properties--datatypes-test-entity.json
@@ -1,0 +1,94 @@
+[
+  {
+    "name": "bigDecimalAttr",
+    "lazy": false
+  },
+  {
+    "name": "booleanAttr",
+    "lazy": false
+  },
+  {
+    "name": "byteArrayAttr",
+    "lazy": false
+  },
+  {
+    "name": "dateAttr",
+    "lazy": false
+  },
+  {
+    "name": "dateTimeAttr",
+    "lazy": false
+  },
+  {
+    "name": "doubleAttr",
+    "lazy": false
+  },
+  {
+    "name": "integerAttr",
+    "lazy": false
+  },
+  {
+    "name": "longAttr",
+    "lazy": false
+  },
+  {
+    "name": "stringAttr",
+    "lazy": false
+  },
+  {
+    "name": "timeAttr",
+    "lazy": false
+  },
+  {
+    "name": "uuidAttr",
+    "lazy": false
+  },
+  {
+    "name": "localDateTimeAttr",
+    "lazy": false
+  },
+  {
+    "name": "offsetDateTimeAttr",
+    "lazy": false
+  },
+  {
+    "name": "localDateAttr",
+    "lazy": false
+  },
+  {
+    "name": "localTimeAttr",
+    "lazy": false
+  },
+  {
+    "name": "offsetTimeAttr",
+    "lazy": false
+  },
+  {
+    "name": "enumAttr",
+    "lazy": false
+  },
+  {
+    "name": "name",
+    "lazy": false
+  },
+  {
+    "name": "associationO2Oattr",
+    "entity": "scr_AssociationO2OTestEntity",
+    "lazy": false
+  },
+  {
+    "name": "associationO2Mattr",
+    "entity": "scr_AssociationO2MTestEntity",
+    "lazy": false
+  },
+  {
+    "name": "associationM2Oattr",
+    "entity": "scr_AssociationM2OTestEntity",
+    "lazy": false
+  },
+  {
+    "name": "associationM2Mattr",
+    "entity": "scr_AssociationM2MTestEntity",
+    "lazy": false
+  }
+]

--- a/packages/front-generator/src/test/generators/react-typrscript/common/entity.test.ts
+++ b/packages/front-generator/src/test/generators/react-typrscript/common/entity.test.ts
@@ -1,0 +1,58 @@
+import {getDisplayedAttributes} from "../../../../generators/react-typescript/common/entity";
+import {expect} from "chai";
+
+const dtViewProperties = require('../../../fixtures/view-properties--datatypes-test-entity.json');
+const o2oViewProperties = require('../../../fixtures/view-properties--association-o2o.json');
+const dtEntityModel = require('../../../fixtures/entity-model--datatypes-test-entity.json');
+const o2oEntityModel = require('../../../fixtures/entity-model--association-o2o.json');
+const projectModel = require('../../../fixtures/project-model--scr.json');
+
+describe('getDisplayedAttributes()', () => {
+  let dtDisplayedFields: string[];
+  let o2oDisplayedFields: string[];
+
+  before(() => {
+    const dtEntityAttrs = getDisplayedAttributes(dtViewProperties, dtEntityModel, projectModel);
+    dtDisplayedFields = dtEntityAttrs.map(attr => attr.name);
+    const o2oEntityAttrs = getDisplayedAttributes(o2oViewProperties, o2oEntityModel, projectModel);
+    o2oDisplayedFields = o2oEntityAttrs.map(attr => attr.name);
+  });
+
+  it('does not include one to many associations', () => {
+    expect(dtDisplayedFields).to.not.include('associationO2Mattr');
+  });
+
+  it('does not include one to one associations on the inverse side', () => {
+    expect(o2oDisplayedFields).to.not.include('datatypesTestEntity');
+  });
+
+  it('does not include byte arrays', () => {
+    expect(dtDisplayedFields).to.not.include('byteArrayAttr');
+  });
+
+  it('includes all other properties', () => {
+    expect(dtDisplayedFields).to.include.members([
+      'bigDecimalAttr',
+      'booleanAttr',
+      'dateAttr',
+      'dateTimeAttr',
+      'doubleAttr',
+      'integerAttr',
+      'longAttr',
+      'stringAttr',
+      'timeAttr',
+      'uuidAttr',
+      'localDateTimeAttr',
+      'offsetDateTimeAttr',
+      'localDateAttr',
+      'localTimeAttr',
+      'offsetTimeAttr',
+      'enumAttr',
+      'name',
+      'associationO2Oattr',
+      'associationM2Oattr',
+      'associationM2Mattr',
+    ]);
+    expect(o2oDisplayedFields).to.include('name');
+  });
+});

--- a/sample-car-rent/modules/global/src/com/company/scr/views.xml
+++ b/sample-car-rent/modules/global/src/com/company/scr/views.xml
@@ -48,9 +48,7 @@
   <view entity="scr_AssociationO2MTestEntity" name="associationO2MTestEntity-view" extends="_local">
     <property name="datatypesTestEntity" view="_minimal"/>
   </view>
-  <view entity="scr_AssociationO2OTestEntity" name="associationO2OTestEntity-view" extends="_local">
-    <property name="datatypesTestEntity" view="_minimal"/>
-  </view>
+  <view entity="scr_AssociationO2OTestEntity" name="associationO2OTestEntity-view" extends="_local"/>
   <view entity="scr_CompositionO2MTestEntity" name="compositionO2MTestEntity-view" extends="_local">
     <property name="datatypesTestEntity" view="_minimal"/>
   </view>

--- a/sample-car-rent/modules/web/src/com/company/scr/web/screens/associationo2otestentity/association-o2o-test-entity-browse.xml
+++ b/sample-car-rent/modules/web/src/com/company/scr/web/screens/associationo2otestentity/association-o2o-test-entity-browse.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <window xmlns="http://schemas.haulmont.com/cuba/screen/window.xsd"
+        xmlns:c="http://schemas.haulmont.com/cuba/screen/jpql_condition.xsd"
         caption="msg://browseCaption"
         focusComponent="associationO2OTestEntitiesTable"
         messagesPack="com.company.scr.web.screens.associationo2otestentity">
@@ -32,7 +33,6 @@
         <action id="remove" type="remove"/>
       </actions>
       <columns>
-        <column id="datatypesTestEntity"/>
         <column id="name"/>
       </columns>
       <rowsCount/>

--- a/sample-car-rent/modules/web/src/com/company/scr/web/screens/associationo2otestentity/association-o2o-test-entity-edit.xml
+++ b/sample-car-rent/modules/web/src/com/company/scr/web/screens/associationo2otestentity/association-o2o-test-entity-edit.xml
@@ -15,12 +15,6 @@
   <layout expand="editActions" spacing="true">
     <form id="form" dataContainer="associationO2OTestEntityDc">
       <column width="250px">
-        <pickerField id="datatypesTestEntityField" property="datatypesTestEntity">
-          <actions>
-            <action id="lookup" type="picker_lookup"/>
-            <action id="clear" type="picker_clear"/>
-          </actions>
-        </pickerField>
         <textField id="nameField" property="name"/>
       </column>
     </form>

--- a/scripts/generate-react-client-scr.js
+++ b/scripts/generate-react-client-scr.js
@@ -52,5 +52,35 @@ gen(
         dest: 'src/app/datatypes-test3',
         answers: answers.datatypesTest3
       },
+      {
+        command: 'react-typescript:entity-management',
+        dirShift,
+        dest: 'src/app/associationO2O',
+        answers: answers.associationO2O
+      },
+      {
+        command: 'react-typescript:entity-management',
+        dirShift,
+        dest: 'src/app/associationO2M',
+        answers: answers.associationO2M
+      },
+      {
+        command: 'react-typescript:entity-management',
+        dirShift,
+        dest: 'src/app/associationM2O',
+        answers: answers.associationM2O
+      },
+      {
+        command: 'react-typescript:entity-management',
+        dirShift,
+        dest: 'src/app/associationM2M',
+        answers: answers.associationM2M
+      },
+      {
+        command: 'react-typescript:entity-cards',
+        dirShift,
+        dest: 'src/app/datatypes-test-cards',
+        answers: answers.datatypesTestCards
+      },
     ]
 );

--- a/scripts/model/react-client-scr-answers.json
+++ b/scripts/model/react-client-scr-answers.json
@@ -104,6 +104,87 @@
     },
     "managementComponentName": "DatatypesManagement3"
   },
+
+  "associationO2O": {
+    "editView": {
+      "name": "associationO2OTestEntity-view",
+      "entityName": "scr_AssociationO2OTestEntity"
+    },
+    "editComponentName": "AssociationO2OEdit",
+    "listView": {
+      "name": "associationO2OTestEntity-view",
+      "entityName": "scr_AssociationO2OTestEntity"
+    },
+    "listComponentName": "AssociationO2OBrowse",
+    "listType": "table",
+    "entity": {
+      "name": "scr_AssociationO2OTestEntity"
+    },
+    "managementComponentName": "AssociationO2OManagement"
+  },
+  "associationO2M": {
+    "editView": {
+      "name": "associationO2MTestEntity-view",
+      "entityName": "scr_AssociationO2MTestEntity"
+    },
+    "editComponentName": "AssociationO2MEdit",
+    "listView": {
+      "name": "associationO2MTestEntity-view",
+      "entityName": "scr_AssociationO2MTestEntity"
+    },
+    "listComponentName": "AssociationO2MBrowse",
+    "listType": "table",
+    "entity": {
+      "name": "scr_AssociationO2MTestEntity"
+    },
+    "managementComponentName": "AssociationO2MManagement"
+  },
+  "associationM2O": {
+    "editView": {
+      "name": "associationM2OTestEntity-view",
+      "entityName": "scr_AssociationM2OTestEntity"
+    },
+    "editComponentName": "AssociationM2OEdit",
+    "listView": {
+      "name": "associationM2OTestEntity-view",
+      "entityName": "scr_AssociationM2OTestEntity"
+    },
+    "listComponentName": "AssociationM2OBrowse",
+    "listType": "table",
+    "entity": {
+      "name": "scr_AssociationM2OTestEntity"
+    },
+    "managementComponentName": "AssociationM2OManagement"
+  },
+  "associationM2M": {
+    "editView": {
+      "name": "associationM2MTestEntity-view",
+      "entityName": "scr_AssociationM2MTestEntity"
+    },
+    "editComponentName": "AssociationM2MEdit",
+    "listView": {
+      "name": "associationM2MTestEntity-view",
+      "entityName": "scr_AssociationM2MTestEntity"
+    },
+    "listComponentName": "AssociationM2MBrowse",
+    "listType": "table",
+    "entity": {
+      "name": "scr_AssociationM2MTestEntity"
+    },
+    "managementComponentName": "AssociationM2MManagement"
+  },
+
+  "datatypesTestCards": {
+    "entityView": {
+      "name": "datatypesTestEntity-view",
+      "entityName": "scr_DatatypesTestEntity"
+    },
+    "componentName": "DatatypesCards",
+    "entity": {
+      "name": "scr_DatatypesTestEntity"
+    }
+  },
+
   "entityCards": {
     "entityView": {
       "name": "favoriteCar-view",


### PR DESCRIPTION
Related to #36 

- ✅ Render `InputNumber` for numeric fields:
```
long, decimal, int, double
```
> Support for big numbers is tracked under separate ticket cuba-platform/frontend#99 as it depends on REST API changes
- ✅ Add support for masked fields. Render masked field for  `uuid`.
- ✅ Fix displaying of Associations:
  - Values of many-to-many Associations are not displayed in DataTable
  - Associations should be shown in the same manner as in the Generic UI:
     - One-to-many Associations are not shown anymore at the owning side
     - One-to-one Associations are not shown anymore at the inverse side
- ✅ Do not display `byteArray` (similar to Generic UI)