### PR TITLE
fix TypeError [ERR_INVALID_ARG_TYPE] on app startup

### DIFF
--- a/packages/front-generator/src/generators/react-typescript/app/template/package.json
+++ b/packages/front-generator/src/generators/react-typescript/app/template/package.json
@@ -15,7 +15,7 @@
     "react-input-mask": "^2.0.4",
     "react-intl": "^3.3.2",
     "react-router-dom": "^4.3.1",
-    "react-scripts": "~3.3.0"
+    "react-scripts": "~3.4.0"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
affects: @cuba-platform/front-generator

ISSUES CLOSED: #131