### PR TITLE
fix: no error message when request failed in entity browser

### DIFF
--- a/packages/cuba-react-core/src/data/Collection.tsx
+++ b/packages/cuba-react-core/src/data/Collection.tsx
@@ -107,7 +107,7 @@ class DataCollectionStoreImpl<T> implements DataCollectionStore<T> {
         return true;
       }))
       .catch(action(() => {
-        this.status = "DONE";
+        this.status = "ERROR";
         return true;
       }));
   };

--- a/packages/cuba-react-ui/src/ui/table/DataTable.tsx
+++ b/packages/cuba-react-ui/src/ui/table/DataTable.tsx
@@ -135,6 +135,17 @@ class DataTableComponent<E> extends React.Component<DataTableProps<E>> {
       }
     ));
 
+    // Display error message if dataCollection.load has failed
+    this.disposers.push(reaction(
+      () => this.props.dataCollection.status,
+      (status) => {
+        const {intl} = this.props;
+        if (status === 'ERROR') {
+          message.error(intl.formatMessage({id: 'common.requestFailed'}));
+        }
+      }
+    ));
+
     // Call corresponding callback(s) when selectedRowKeys is changed
     this.disposers.push(reaction(
       () => this.selectedRowKeys,
@@ -231,17 +242,7 @@ class DataTableComponent<E> extends React.Component<DataTableProps<E>> {
 
     handleTableChange<E>({
       pagination, filters, sorter, defaultSort, fields, mainStore, dataCollection
-    }).finally(() => {
-      this.checkDataCollectionStatus();
     });
-  };
-
-  checkDataCollectionStatus = () => {
-    const {dataCollection, intl} = this.props;
-
-    if (dataCollection.status === 'ERROR') {
-      message.error(intl.formatMessage({id: 'cubaReact.dataTable.failedToLoad'}));
-    }
   };
 
   @action
@@ -321,9 +322,7 @@ class DataTableComponent<E> extends React.Component<DataTableProps<E>> {
         this.props.dataCollection.filter = undefined;
       }
     }
-    load().finally(() => {
-      this.checkDataCollectionStatus();
-    });
+    load();
   };
 
   get rowSelectionType(): RowSelectionType {

--- a/packages/front-generator/src/generators/react-typescript/app/template/src/i18n/en.json
+++ b/packages/front-generator/src/generators/react-typescript/app/template/src/i18n/en.json
@@ -6,6 +6,7 @@
   "common.edit": "Edit",
   "common.remove": "Remove",
   "common.unsavedEntity": "(unsaved or unnamed entity)",
+  "common.requestFailed": "Failed to perform the requested operation",
 
   "home.welcome": "Welcome to",
   "router.home": "Home",
@@ -20,7 +21,6 @@
   "cubaReact.dataTable.clearAllFilters": "Clear filters",
   "cubaReact.dataTable.validation.requiredField": "Required field",
   "cubaReact.dataTable.validation.uuid": "Not a valid UUID",
-  "cubaReact.dataTable.failedToLoad": "Failed to load entities",
   "cubaReact.dataTable.failedToLoadNestedEntities": "Failed to load nested entities list",
   "cubaReact.dataTable.loading": "Loading...",
 

--- a/packages/front-generator/src/generators/react-typescript/app/template/src/i18n/ru.json
+++ b/packages/front-generator/src/generators/react-typescript/app/template/src/i18n/ru.json
@@ -6,6 +6,7 @@
   "common.edit": "Изменить",
   "common.remove": "Удалить",
   "common.unsavedEntity": "(несохранённая сущность или сущность без имени)",
+  "common.requestFailed": "Не удалось выполнить операцию",
 
   "home.welcome": "Добро пожаловать в",
   "router.home": "Главная страница",
@@ -20,7 +21,6 @@
   "cubaReact.dataTable.clearAllFilters": "Очистить фильтры",
   "cubaReact.dataTable.validation.requiredField": "Обязательное поле",
   "cubaReact.dataTable.validation.uuid": "Не является валидным UUID",
-  "cubaReact.dataTable.failedToLoad": "Не удалось загрузить сущности",
   "cubaReact.dataTable.failedToLoadNestedEntities": "Не удалось загрузить вложенные сущности",
   "cubaReact.dataTable.loading": "Загрузка...",
 

--- a/packages/front-generator/src/generators/react-typescript/entity-management/template/Cards.tsx.ejs
+++ b/packages/front-generator/src/generators/react-typescript/entity-management/template/Cards.tsx.ejs
@@ -3,7 +3,7 @@ import { observer } from "mobx-react";
 import { Link } from "react-router-dom";
 import { IReactionDisposer, reaction } from "mobx";
 
-import { Modal, Button, Card, Icon } from "antd";
+import { Modal, Button, Card, Icon, message } from "antd";
 
 import {
   collection,
@@ -42,7 +42,7 @@ class <%= listComponentName %>Component extends React.Component<Props> {
     loadImmediately: false
   });
 
-  reactionDisposer: IReactionDisposer;
+  reactionDisposers: IReactionDisposer[] = [];
   fields = [
   <% listAttributes.forEach(p => { -%>
     '<%= p.name %>',
@@ -50,16 +50,26 @@ class <%= listComponentName %>Component extends React.Component<Props> {
   ];
 
   componentDidMount(): void {
-    this.reactionDisposer = reaction(
+    this.reactionDisposers.push(reaction(
       () => this.props.paginationConfig,
       paginationConfig =>
         setPagination(paginationConfig, this.dataCollection, true)
-    );
+    ));
     setPagination(this.props.paginationConfig, this.dataCollection, true);
+
+    this.reactionDisposers.push(reaction(
+      () => this.dataCollection.status,
+      (status) => {
+        const {intl} = this.props;
+        if (status === 'ERROR') {
+          message.error(intl.formatMessage({id: 'common.requestFailed'}));
+        }
+      }
+    ));
   }
 
   componentWillUnmount() {
-    this.reactionDisposer();
+    this.reactionDisposers.forEach(dispose => dispose());
   }
 
   showDeletionDialog = (e: SerializedEntity<<%= entity.className %>>) => {

--- a/packages/front-generator/src/generators/react-typescript/entity-management/template/List.tsx.ejs
+++ b/packages/front-generator/src/generators/react-typescript/entity-management/template/List.tsx.ejs
@@ -3,7 +3,7 @@ import {observer} from "mobx-react";
 import {Link} from "react-router-dom";
 import {IReactionDisposer, reaction} from "mobx";
 
-import {Modal, Button, List, Icon} from "antd";
+import {Modal, Button, List, Icon, message} from "antd";
 
 import {collection, injectMainStore, MainStoreInjected} from "@cuba-platform/react-core";
 import {EntityProperty, Paging, setPagination, Spinner} from "@cuba-platform/react-ui";
@@ -30,7 +30,7 @@ class <%= listComponentName %>Component extends React.Component<Props> {
     loadImmediately: false
   });
 
-  reactionDisposer: IReactionDisposer;
+  reactionDisposers: IReactionDisposer[] = [];
   fields = [
   <% listAttributes.forEach(p => { -%>
     '<%= p.name %>',
@@ -38,14 +38,24 @@ class <%= listComponentName %>Component extends React.Component<Props> {
   ];
 
   componentDidMount(): void {
-    this.reactionDisposer = reaction(() => this.props.paginationConfig,
+    this.reactionDisposers.push(reaction(() => this.props.paginationConfig,
       paginationConfig => setPagination(paginationConfig, this.dataCollection, true)
-    );
+    ));
     setPagination(this.props.paginationConfig, this.dataCollection, true);
+
+    this.reactionDisposers.push(reaction(
+      () => this.dataCollection.status,
+      (status) => {
+        const {intl} = this.props;
+        if (status === 'ERROR') {
+          message.error(intl.formatMessage({id: 'common.requestFailed'}));
+        }
+      }
+    ));
   }
 
   componentWillUnmount() {
-    this.reactionDisposer();
+    this.reactionDisposers.forEach(dispose => dispose());
   }
 
   showDeletionDialog = (e: SerializedEntity<<%= entity.className %>>) => {


### PR DESCRIPTION
affects: @cuba-platform/react-core, @cuba-platform/react-ui, @cuba-platform/front-generator