### PR TITLE
Editor behavior when backend can not be reached

### DIFF
--- a/packages/cuba-react-core/src/data/DataContext.tsx
+++ b/packages/cuba-react-core/src/data/DataContext.tsx
@@ -7,7 +7,7 @@ export interface DataContainer {
   status: DataContainerStatus
 }
 
-export type DataContainerStatus = 'CLEAN' | 'LOADING' | 'DONE' | 'ERROR';
+export type DataContainerStatus = 'CLEAN' | 'LOADING' | 'DONE' | 'ERROR' | 'COMMIT_ERROR';
 
 export interface Containers {
   [containerId: string]: DataContainer;

--- a/packages/cuba-react-core/src/data/Instance.tsx
+++ b/packages/cuba-react-core/src/data/Instance.tsx
@@ -139,7 +139,7 @@ export class DataInstanceStore<T> implements DataContainer {
         return updateResult;
       })
       .catch((e) => {
-        this.status = 'ERROR';
+        this.status = 'COMMIT_ERROR';
         throw e;
       })
   };

--- a/packages/front-generator/src/generators/react-typescript/entity-management/template/EntityManagementEditor.tsx.ejs
+++ b/packages/front-generator/src/generators/react-typescript/entity-management/template/EntityManagementEditor.tsx.ejs
@@ -128,6 +128,10 @@ class <%= editComponentClass %>Component extends React.Component<Props & Wrapped
       return <Spinner/>;
     }
 
+    if (status === "ERROR") {
+      return <></>;
+    }
+
     return (
       <Card className='narrow-layout'>
         <Form onSubmit={this.handleSubmit}
@@ -180,7 +184,7 @@ class <%= editComponentClass %>Component extends React.Component<Props & Wrapped
             </Link>
             <Button type="primary"
                     htmlType="submit"
-                    disabled={status !== "DONE" && status !== "ERROR"}
+                    disabled={status !== "DONE" && status !== "COMMIT_ERROR"}
                     loading={status === "LOADING"}
                     style={{marginLeft: '8px'}}>
               <FormattedMessage id='management.editor.submit'/>
@@ -197,6 +201,28 @@ class <%= editComponentClass %>Component extends React.Component<Props & Wrapped
     } else {
       this.dataInstance.setItem(new <%= entity.className %>());
     }
+
+    this.reactionDisposers.push(
+      reaction(
+        () => this.dataInstance.item,
+        () => {
+          this.props.form.setFieldsValue(
+            this.dataInstance.getFieldValues(this.fields)
+          );
+        }
+      ));
+
+    this.reactionDisposers.push(
+      reaction(
+        () => this.dataInstance.status,
+        status => {
+          const { intl } = this.props;
+          if (status === "ERROR") {
+            message.error(intl.formatMessage({ id: "common.requestFailed" }));
+          }
+        }
+      )
+    );
 
     <% if (Object.keys(editAssociations).length > 0) { %>
       this.reactionDisposers.push(reaction(

--- a/packages/front-generator/src/test/fixtures/react-client/src/app/entity-management/CarEdit.tsx
+++ b/packages/front-generator/src/test/fixtures/react-client/src/app/entity-management/CarEdit.tsx
@@ -183,6 +183,9 @@ class CarEditComponent extends React.Component<Props & WrappedComponentProps> {
     if (mainStore == null || !mainStore.isEntityDataLoaded()) {
       return <Spinner />;
     }
+    if (status === "ERROR") {
+      return <></>;
+    }
 
     return (
       <Card className="narrow-layout">
@@ -325,7 +328,7 @@ class CarEditComponent extends React.Component<Props & WrappedComponentProps> {
             <Button
               type="primary"
               htmlType="submit"
-              disabled={status !== "DONE" && status !== "ERROR"}
+              disabled={status !== "DONE" && status !== "COMMIT_ERROR"}
               loading={status === "LOADING"}
               style={{ marginLeft: "8px" }}
             >
@@ -343,6 +346,28 @@ class CarEditComponent extends React.Component<Props & WrappedComponentProps> {
     } else {
       this.dataInstance.setItem(new Car());
     }
+
+    this.reactionDisposers.push(
+      reaction(
+        () => this.dataInstance.item,
+        () => {
+          this.props.form.setFieldsValue(
+            this.dataInstance.getFieldValues(this.fields)
+          );
+        }
+      )
+    );
+    this.reactionDisposers.push(
+      reaction(
+        () => this.dataInstance.status,
+        status => {
+          const { intl } = this.props;
+          if (status === "ERROR") {
+            message.error(intl.formatMessage({ id: "common.requestFailed" }));
+          }
+        }
+      )
+    );
 
     this.reactionDisposers.push(
       reaction(

--- a/packages/front-generator/src/test/fixtures/react-client/src/app/entity-management/CarEditLowCase.tsx
+++ b/packages/front-generator/src/test/fixtures/react-client/src/app/entity-management/CarEditLowCase.tsx
@@ -185,6 +185,9 @@ class CarEditLowCaseComponent extends React.Component<
     if (mainStore == null || !mainStore.isEntityDataLoaded()) {
       return <Spinner />;
     }
+    if (status === "ERROR") {
+      return <></>;
+    }
 
     return (
       <Card className="narrow-layout">
@@ -327,7 +330,7 @@ class CarEditLowCaseComponent extends React.Component<
             <Button
               type="primary"
               htmlType="submit"
-              disabled={status !== "DONE" && status !== "ERROR"}
+              disabled={status !== "DONE" && status !== "COMMIT_ERROR"}
               loading={status === "LOADING"}
               style={{ marginLeft: "8px" }}
             >
@@ -345,6 +348,28 @@ class CarEditLowCaseComponent extends React.Component<
     } else {
       this.dataInstance.setItem(new Car());
     }
+
+    this.reactionDisposers.push(
+      reaction(
+        () => this.dataInstance.item,
+        () => {
+          this.props.form.setFieldsValue(
+            this.dataInstance.getFieldValues(this.fields)
+          );
+        }
+      )
+    );
+    this.reactionDisposers.push(
+      reaction(
+        () => this.dataInstance.status,
+        status => {
+          const { intl } = this.props;
+          if (status === "ERROR") {
+            message.error(intl.formatMessage({ id: "common.requestFailed" }));
+          }
+        }
+      )
+    );
 
     this.reactionDisposers.push(
       reaction(

--- a/packages/front-generator/src/test/fixtures/templates/EntityManagementEditor.tsx
+++ b/packages/front-generator/src/test/fixtures/templates/EntityManagementEditor.tsx
@@ -145,6 +145,10 @@ class CarEditComponent extends React.Component<Props & WrappedComponentProps> {
       return <Spinner />;
     }
 
+    if (status === "ERROR") {
+      return <></>;
+    }
+
     return (
       <Card className="narrow-layout">
         <Form onSubmit={this.handleSubmit} layout="vertical" ref={this.formRef}>
@@ -202,7 +206,7 @@ class CarEditComponent extends React.Component<Props & WrappedComponentProps> {
             <Button
               type="primary"
               htmlType="submit"
-              disabled={status !== "DONE" && status !== "ERROR"}
+              disabled={status !== "DONE" && status !== "COMMIT_ERROR"}
               loading={status === "LOADING"}
               style={{ marginLeft: "8px" }}
             >
@@ -220,6 +224,29 @@ class CarEditComponent extends React.Component<Props & WrappedComponentProps> {
     } else {
       this.dataInstance.setItem(new Car());
     }
+
+    this.reactionDisposers.push(
+      reaction(
+        () => this.dataInstance.item,
+        () => {
+          this.props.form.setFieldsValue(
+            this.dataInstance.getFieldValues(this.fields)
+          );
+        }
+      )
+    );
+
+    this.reactionDisposers.push(
+      reaction(
+        () => this.dataInstance.status,
+        status => {
+          const { intl } = this.props;
+          if (status === "ERROR") {
+            message.error(intl.formatMessage({ id: "common.requestFailed" }));
+          }
+        }
+      )
+    );
 
     this.reactionDisposers.push(
       reaction(


### PR DESCRIPTION
affects: @cuba-platform/react-core, @cuba-platform/front-generator

error message should be shown when item could not be loaded from backend
relates: #154