### PR TITLE
docs: add search

### DIFF
--- a/docs-src/antora-playbook.yml
+++ b/docs-src/antora-playbook.yml
@@ -9,7 +9,6 @@ content:
     - url: https://github.com/cuba-platform/frontend.git
       branches:
         - develop
-#        - pv/docs/2.0
 #        - master
 #        - v[0-9]*
       start_path: docs-src/doc-component-repo

--- a/docs-src/supplemental-ui/partials/footer-scripts.hbs
+++ b/docs-src/supplemental-ui/partials/footer-scripts.hbs
@@ -1,0 +1,13 @@
+<!--This Source Code Form is subject to the terms of the Mozilla Public-->
+<!--License, v. 2.0. If a copy of the MPL was not distributed with this-->
+<!--file, You can obtain one at http://mozilla.org/MPL/2.0/.-->
+<script src="{{uiRootPath}}/js/site.js"></script>
+<script async src="{{uiRootPath}}/js/vendor/highlight.js"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+<script type="text/javascript"> docsearch({
+    apiKey: 'cc78e5e3b5049817bb14460f9e316448',
+    indexName: 'cuba-platform',
+    inputSelector: '#search-input',
+    debug: false // Set debug to true if you want to inspect the dropdown
+});
+</script>

--- a/docs-src/supplemental-ui/partials/head-styles.hbs
+++ b/docs-src/supplemental-ui/partials/head-styles.hbs
@@ -1,0 +1,5 @@
+<!--This Source Code Form is subject to the terms of the Mozilla Public-->
+<!--License, v. 2.0. If a copy of the MPL was not distributed with this-->
+<!--file, You can obtain one at http://mozilla.org/MPL/2.0/.-->
+<link rel="stylesheet" href="{{uiRootPath}}/css/site.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />

--- a/docs-src/supplemental-ui/partials/header-content.hbs
+++ b/docs-src/supplemental-ui/partials/header-content.hbs
@@ -8,6 +8,13 @@
     </div>
     <div id="topbar-nav" class="navbar-menu">
           <div class="navbar-end">
+              <div class="navbar-item">
+                  <input id="search-input"
+                         placeholder="Search docs"
+                         onfocusout="this.value=''"
+                         style="font-size: 16px;"
+                  />
+              </div>
               <div class="navbar-item has-dropdown is-hoverable">
                   <div class="navbar-link">Libraries API Reference</div>
                   <div class="navbar-dropdown">

--- a/docs-src/supplemental-ui/partials/header-content.hbs
+++ b/docs-src/supplemental-ui/partials/header-content.hbs
@@ -1,8 +1,17 @@
 <!--This Source Code Form is subject to the terms of the Mozilla Public-->
 <!--License, v. 2.0. If a copy of the MPL was not distributed with this-->
 <!--file, You can obtain one at http://mozilla.org/MPL/2.0/.-->
+<style>
+    .cuba-header.navbar {
+        background: #0b6ec7;
+    }
+    .navbar-item.has-dropdown:hover .navbar-link.cuba-header-item,
+    .navbar-end>a.navbar-item.cuba-header-item:hover {
+        background-color: #0963b3;
+    }
+</style>
 <header class="header">
-  <nav class="navbar">
+  <nav class="navbar cuba-header">
     <div class="navbar-brand">
       <a class="navbar-item" href="{{or site.url (or siteRootUrl siteRootPath)}}">CUBA Platform Frontend UI</a>
     </div>
@@ -16,7 +25,7 @@
                   />
               </div>
               <div class="navbar-item has-dropdown is-hoverable">
-                  <div class="navbar-link">Libraries API Reference</div>
+                  <div class="navbar-link cuba-header-item">Libraries API Reference</div>
                   <div class="navbar-dropdown">
                       <a class="navbar-item is-hoverable" href="../api-reference/cuba-rest-js/index.html" target="_blank">
                           CUBA REST JS
@@ -29,7 +38,7 @@
                       </a>
                   </div>
               </div>
-              <a class="navbar-item is-hoverable" href="https://github.com/cuba-platform/frontend" target="_blank">
+              <a class="navbar-item is-hoverable cuba-header-item" href="https://github.com/cuba-platform/frontend" target="_blank">
                   GitHub Home
               </a>
            </div>


### PR DESCRIPTION
related to #173

You can build the site locally (`npm run doc:site`) and play with the search (it will use the index of and will redirect to the deployed docs site).