### PR TITLE
fix(React): backward compatibility for CUBA REST 7.2 permission model

### DIFF
--- a/packages/cuba-rest-js/dist-browser/cuba.js
+++ b/packages/cuba-rest-js/dist-browser/cuba.js
@@ -269,11 +269,14 @@ var CubaApp = /** @class */ (function () {
         return fetchRes;
     };
     CubaApp.prototype.getPermissions = function (fetchOptions) {
-        return this.fetch('GET', 'v2/permissions', null, __assign({ handleAs: 'json' }, fetchOptions));
+        // https://github.com/cuba-platform/frontend/issues/177
+        // security model is changed in cuba rest 7.2 so we do not support roles and permission at this moment
+        return Promise.resolve([]);
     };
     CubaApp.prototype.getRoles = function (fetchOptions) {
-        var _this = this;
-        return this.requestIfSupported('7.2', function () { return _this.fetch('GET', 'v2/roles', null, __assign({ handleAs: 'json' }, fetchOptions)); });
+        // https://github.com/cuba-platform/frontend/issues/177
+        // security model is changed in cuba rest 7.2 so we do not support roles and permission at this moment
+        return Promise.reject(CubaApp.NOT_SUPPORTED_BY_API_VERSION);
     };
     CubaApp.prototype.getUserInfo = function (fetchOptions) {
         return this.fetch('GET', 'v2/userInfo', null, __assign({ handleAs: 'json' }, fetchOptions));

--- a/packages/cuba-rest-js/dist-node/cuba.js
+++ b/packages/cuba-rest-js/dist-node/cuba.js
@@ -268,11 +268,14 @@ var CubaApp = /** @class */ (function () {
         return fetchRes;
     };
     CubaApp.prototype.getPermissions = function (fetchOptions) {
-        return this.fetch('GET', 'v2/permissions', null, __assign({ handleAs: 'json' }, fetchOptions));
+        // https://github.com/cuba-platform/frontend/issues/177
+        // security model is changed in cuba rest 7.2 so we do not support roles and permission at this moment
+        return Promise.resolve([]);
     };
     CubaApp.prototype.getRoles = function (fetchOptions) {
-        var _this = this;
-        return this.requestIfSupported('7.2', function () { return _this.fetch('GET', 'v2/roles', null, __assign({ handleAs: 'json' }, fetchOptions)); });
+        // https://github.com/cuba-platform/frontend/issues/177
+        // security model is changed in cuba rest 7.2 so we do not support roles and permission at this moment
+        return Promise.reject(CubaApp.NOT_SUPPORTED_BY_API_VERSION);
     };
     CubaApp.prototype.getUserInfo = function (fetchOptions) {
         return this.fetch('GET', 'v2/userInfo', null, __assign({ handleAs: 'json' }, fetchOptions));

--- a/packages/cuba-rest-js/src/cuba.ts
+++ b/packages/cuba-rest-js/src/cuba.ts
@@ -334,13 +334,15 @@ export class CubaApp {
   }
 
   public getPermissions(fetchOptions?: FetchOptions): Promise<PermissionInfo[]> {
-    return this.fetch('GET', 'v2/permissions', null, {handleAs: 'json', ...fetchOptions});
+    // https://github.com/cuba-platform/frontend/issues/177
+    // security model is changed in cuba rest 7.2 so we do not support roles and permission at this moment
+    return Promise.resolve([]);
   }
 
   public getRoles(fetchOptions?: FetchOptions): Promise<RolesInfo> {
-    return this.requestIfSupported(
-      '7.2',
-      () => this.fetch('GET', 'v2/roles', null, {handleAs: 'json', ...fetchOptions}));
+    // https://github.com/cuba-platform/frontend/issues/177
+    // security model is changed in cuba rest 7.2 so we do not support roles and permission at this moment
+    return Promise.reject(CubaApp.NOT_SUPPORTED_BY_API_VERSION);
   }
 
   public getUserInfo(fetchOptions?: FetchOptions): Promise<UserInfo> {


### PR DESCRIPTION
affects: @cuba-platform/react, @cuba-platform/rest

getRoles and getPermissions methods is noop in case of new CUBA REST permission model