### PR TITLE
fix(React): two letter options (-vb -ds) not work in generator cli

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -3,7 +3,7 @@ module.exports = {
   rules: {
     'scope-enum': [2, 'always', [
       'React', 'React Native', 'SDK',
-      'DataTable'
+      'DataTable', 'Front Generator'
     ]],
     'scope-case': [0],
     'type-enum': [2, 'always', [

--- a/docs-src/doc-component-repo/modules/generator/pages/commands-reference.adoc
+++ b/docs-src/doc-component-repo/modules/generator/pages/commands-reference.adoc
@@ -32,7 +32,7 @@ Generates:
 
     -d, --dest [dest]           destination directory
     -m, --model [model]         specify path to project model, if given no interactive prompt will be invoked
-    -ds, --dirShift [dirShift]  directory shift for html imports e.g ../../
+    -s, --dirShift [dirShift]  directory shift for html imports e.g ../../
     -a, --answers [answers]     fulfilled params for generator to avoid interactive input in serialized JSON string
     -h, --help                  output usage information
 ....
@@ -85,7 +85,7 @@ Generates a list of entities where each entity is represented by a card (similar
 
     -d, --dest [dest]           destination directory
     -m, --model [model]         specify path to project model, if given no interactive prompt will be invoked
-    -ds, --dirShift [dirShift]  directory shift for html imports e.g ../../
+    -s, --dirShift [dirShift]  directory shift for html imports e.g ../../
     -a, --answers [answers]     fulfilled params for generator to avoid interactive input in serialized JSON string
     -h, --help                  output usage information
 ....
@@ -116,7 +116,7 @@ Generates a blank component.
 
     -d, --dest [dest]           destination directory
     -m, --model [model]         specify path to project model, if given no interactive prompt will be invoked
-    -ds, --dirShift [dirShift]  directory shift for html imports e.g ../../
+    -s, --dirShift [dirShift]  directory shift for html imports e.g ../../
     -a, --answers [answers]     fulfilled params for generator to avoid interactive input in serialized JSON string
     -h, --help                  output usage information
 ....
@@ -138,7 +138,7 @@ Generates a React Native starter app. See xref:client-react-native:starter-guide
 
     -d, --dest [dest]    destination directory
     -m, --model [model]  specify path to project model, if given no interactive prompt will be invoked
-    -vb, --verbose       log out additional info about generation process
+    -b, --verbose       log out additional info about generation process
     -h, --help           output usage information
 ....
 

--- a/packages/front-generator/src/common/cli-options.ts
+++ b/packages/front-generator/src/common/cli-options.ts
@@ -56,7 +56,7 @@ export const commonGenerationOptionsConfig: OptionsConfig = {
     type: String
   },
   verbose: {
-    alias: 'vb',
+    alias: 'b',
     description: 'log out additional info about generation process',
     type: Boolean
   }
@@ -69,7 +69,7 @@ export interface PolymerElementOptions extends CommonGenerationOptions {
 export const polymerElementOptionsConfig: OptionsConfig = {
   ...commonGenerationOptionsConfig,
   dirShift: {
-    alias: 'ds',
+    alias: 's',
     description: 'directory shift for html imports e.g ../../',
     type: String
   },


### PR DESCRIPTION
affects: @cuba-platform/front-generator

yeoman doesn't support two-letter shortcuts, started from the same letter, all shortcuts changed to single letter

relates: #175