### PR TITLE
fix(Front Generator): capitalize component class names

### DIFF
--- a/packages/front-generator/src/generators/react-typescript/blank-component/index.ts
+++ b/packages/front-generator/src/generators/react-typescript/blank-component/index.ts
@@ -6,7 +6,6 @@ import {StudioTemplateProperty} from "../../../common/studio/studio-model";
 import {elementNameToClass, unCapitalizeFirst} from "../../../common/utils";
 import {CommonTemplateModel} from "../../polymer2/common/template-model";
 import {addToMenu} from "../common/menu";
-import {Entity, View} from "../../../common/model/cuba-model";
 
 export interface BlankComponentAnswers {
   componentName: string
@@ -33,7 +32,7 @@ class ReactComponentGenerator extends BaseGenerator<BlankComponentAnswers, Blank
     this.model = blankComponentAnswersToModel(this.answers, this.options.dirShift);
     this.fs.copyTpl(
       this.templatePath('Component.tsx'),
-      this.destinationPath(this.model.componentName + '.tsx'), this.model
+      this.destinationPath(this.model.className + '.tsx'), this.model
     );
     if (!addToMenu(this.fs, {
       componentFileName: this.model.className,

--- a/packages/front-generator/src/generators/react-typescript/blank-component/template/Component.tsx
+++ b/packages/front-generator/src/generators/react-typescript/blank-component/template/Component.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 
-export class <%= componentName %> extends React.Component {
+export class <%= className %> extends React.Component {
   render() {
     return(
       <div>
-        <%= componentName %>
+        <%= className %>
       </div>
     )
   }

--- a/packages/front-generator/src/generators/react-typescript/entity-management/index.ts
+++ b/packages/front-generator/src/generators/react-typescript/entity-management/index.ts
@@ -34,7 +34,7 @@ class ReactEntityManagementGenerator extends BaseGenerator<EntityManagementAnswe
       throw new Error('Answers not provided');
     }
     this.model = answersToManagementModel(this.answers, this.cubaProjectModel!, this.options.dirShift);
-    const {className, listComponentName, editComponentName, listType} = this.model;
+    const {className, listComponentClass, editComponentClass, listType} = this.model;
 
     const extension = '.tsx.ejs';
     this.fs.copyTpl(
@@ -45,11 +45,11 @@ class ReactEntityManagementGenerator extends BaseGenerator<EntityManagementAnswe
     const listTemplateFile = capitalizeFirst(listType) + extension;
     this.fs.copyTpl(
       this.templatePath(listTemplateFile),
-      this.destinationPath(listComponentName + extension), this.model
+      this.destinationPath(listComponentClass + extension), this.model
     );
     this.fs.copyTpl(
       this.templatePath('EntityManagementEditor' + extension),
-      this.destinationPath(editComponentName + extension), this.model
+      this.destinationPath(editComponentClass + extension), this.model
     );
 
     writeComponentI18nMessages(
@@ -127,7 +127,7 @@ class ReactEntityManagementGenerator extends BaseGenerator<EntityManagementAnswe
   }
 }
 
-export function answersToManagementModel(answers: EntityManagementAnswers,
+function answersToManagementModel(answers: EntityManagementAnswers,
                                          projectModel:ProjectModel,
                                          dirShift: string | undefined): EntityManagementTemplateModel {
   const className = elementNameToClass(answers.managementComponentName);
@@ -150,8 +150,8 @@ export function answersToManagementModel(answers: EntityManagementAnswers,
     componentName: answers.managementComponentName,
     className,
     relDirShift: dirShift || '',
-    listComponentName: answers.listComponentName,
-    editComponentName: answers.editComponentName,
+    listComponentClass: elementNameToClass(answers.listComponentName),
+    editComponentClass: elementNameToClass(answers.editComponentName),
     listType: answers.listType,
     nameLiteral: unCapitalizeFirst(className),
     entity,

--- a/packages/front-generator/src/generators/react-typescript/entity-management/template-model.ts
+++ b/packages/front-generator/src/generators/react-typescript/entity-management/template-model.ts
@@ -17,8 +17,8 @@ export interface RelationImport {
 }
 
 export interface EntityManagementTemplateModel extends CommonTemplateModel {
-  listComponentName: string;
-  editComponentName: string;
+  listComponentClass: string;
+  editComponentClass: string;
   listType: EntityManagementListType;
   nameLiteral: string;
   entity: EntityTemplateModel;

--- a/packages/front-generator/src/generators/react-typescript/entity-management/template/Cards.tsx.ejs
+++ b/packages/front-generator/src/generators/react-typescript/entity-management/template/Cards.tsx.ejs
@@ -34,7 +34,7 @@ onPagingChange: (current: number, pageSize: number) => void;
 };
 @injectMainStore
 @observer
-class <%= listComponentName %>Component extends React.Component<Props> {
+class <%= listComponentClass %>Component extends React.Component<Props> {
 
   dataCollection = collection<<%= entity.className %>>(<%= entity.className %>.NAME, {
     view: '<%= listView.name %>',
@@ -145,6 +145,6 @@ class <%= listComponentName %>Component extends React.Component<Props> {
   }
 }
 
-const <%=listComponentName%> = injectIntl(<%=listComponentName%>Component);
+const <%=listComponentClass%> = injectIntl(<%=listComponentClass%>Component);
 
-export default <%=listComponentName%>;
+export default <%=listComponentClass%>;

--- a/packages/front-generator/src/generators/react-typescript/entity-management/template/EntityManagement.tsx.ejs
+++ b/packages/front-generator/src/generators/react-typescript/entity-management/template/EntityManagement.tsx.ejs
@@ -1,8 +1,8 @@
 import * as React from "react";
 import {RouteComponentProps} from "react-router";
 import {observer} from "mobx-react";
-import <%= editComponentName %> from "./<%= editComponentName %>";
-import <%= listComponentName %> from "./<%= listComponentName %>";
+import <%= editComponentClass %> from "./<%= editComponentClass %>";
+import <%= listComponentClass %> from "./<%= listComponentClass %>";
 import {PaginationConfig} from "antd/es/pagination";
 import {action, observable} from "mobx";
 import {addPagingParams, createPagingConfig, defaultPagingConfig} from "@cuba-platform/react-ui";
@@ -25,8 +25,8 @@ export class <%= className %> extends React.Component<Props> {
     const {entityId} = this.props.match.params;
     return (
       entityId
-          ? < <%= editComponentName %> entityId={entityId}/>
-          : < <%= listComponentName %>
+          ? < <%= editComponentClass %> entityId={entityId}/>
+          : < <%= listComponentClass %>
 
     <% if (listType === 'list' || listType === 'cards') { %> <%# if clause will be removed after paging impleneted on other list types %>
         onPagingChange={this.onPagingChange}

--- a/packages/front-generator/src/generators/react-typescript/entity-management/template/EntityManagementEditor.tsx.ejs
+++ b/packages/front-generator/src/generators/react-typescript/entity-management/template/EntityManagementEditor.tsx.ejs
@@ -41,7 +41,7 @@ type EditorProps = {
 
 @injectMainStore
 @observer
-class <%= editComponentName %>Component extends React.Component<Props & WrappedComponentProps> {
+class <%= editComponentClass %>Component extends React.Component<Props & WrappedComponentProps> {
 
   dataInstance = instance<<%= entity.className %>>(<%= entity.className %>.NAME, {view: '<%= editView.name %>', loadImmediately: false});
 
@@ -204,4 +204,4 @@ export default injectIntl(withLocalizedForm<EditorProps>({
       })
     });
   }
-})(<%= editComponentName %>Component));
+})(<%= editComponentClass %>Component));

--- a/packages/front-generator/src/generators/react-typescript/entity-management/template/List.tsx.ejs
+++ b/packages/front-generator/src/generators/react-typescript/entity-management/template/List.tsx.ejs
@@ -22,7 +22,7 @@ onPagingChange: (current: number, pageSize: number) => void;
 
 @injectMainStore
 @observer
-class <%= listComponentName %>Component extends React.Component<Props> {
+class <%= listComponentClass %>Component extends React.Component<Props> {
 
   dataCollection = collection<<%= entity.className %>>(<%= entity.className %>.NAME, {
     view: '<%= listView.name %>',
@@ -130,6 +130,6 @@ class <%= listComponentName %>Component extends React.Component<Props> {
   }
 }
 
-const <%=listComponentName%> = injectIntl(<%=listComponentName%>Component);
+const <%=listComponentClass%> = injectIntl(<%=listComponentClass%>Component);
 
-export default <%=listComponentName%>;
+export default <%=listComponentClass%>;

--- a/packages/front-generator/src/generators/react-typescript/entity-management/template/Table.tsx.ejs
+++ b/packages/front-generator/src/generators/react-typescript/entity-management/template/Table.tsx.ejs
@@ -14,7 +14,7 @@ import {FormattedMessage, injectIntl, WrappedComponentProps} from 'react-intl';
 
 @injectMainStore
 @observer
-class <%= listComponentName %>Component extends React.Component<MainStoreInjected & WrappedComponentProps> {
+class <%= listComponentClass %>Component extends React.Component<MainStoreInjected & WrappedComponentProps> {
 
   dataCollection = collection<<%= entity.className %>>(<%= entity.className %>.NAME, {view: '<%= listView.name %>', sort: '-updateTs'});
   @observable selectedRowKey: string | undefined;
@@ -104,6 +104,6 @@ class <%= listComponentName %>Component extends React.Component<MainStoreInjecte
 
 }
 
-const <%=listComponentName%> = injectIntl(<%=listComponentName%>Component);
+const <%=listComponentClass%> = injectIntl(<%=listComponentClass%>Component);
 
-export default <%=listComponentName%>;
+export default <%=listComponentClass%>;

--- a/packages/front-generator/src/test/fixtures/answers.json
+++ b/packages/front-generator/src/test/fixtures/answers.json
@@ -2,6 +2,9 @@
   "blankComponent": {
     "componentName": "BlankComponent"
   },
+  "blankComponentLowCase": {
+    "componentName": "blankComponent"
+  },
   "entityManagement": {
     "editView": {
       "name": "car-edit",
@@ -53,6 +56,23 @@
     },
     "managementComponentName": "CarManagement3"
   },
+  "entityManagementLowCase": {
+    "editView": {
+      "name": "car-edit",
+      "entityName": "mpg$Car"
+    },
+    "editComponentName": "carEditLowCase",
+    "listView": {
+      "name": "car-edit",
+      "entityName": "mpg$Car"
+    },
+    "listComponentName": "carTableLowCase",
+    "listType": "table",
+    "entity": {
+      "name": "mpg$Car"
+    },
+    "managementComponentName": "carManagementLowCase"
+  },
   "entityCards": {
     "entityView": {
       "name": "favoriteCar-view",
@@ -61,26 +81,6 @@
     "componentName": "mpg-favorite-car-cards",
     "entity": {
       "name": "mpg$FavoriteCar"
-    }
-  },
-  "entityList": {
-    "entityView": {
-      "name": "_local",
-      "entityName": "mpg$Garage"
-    },
-    "componentName": "mpg-garage-list",
-    "entity": {
-      "name": "mpg$Garage"
-    }
-  },
-  "entityEdit": {
-    "editView": {
-      "name": "car-edit",
-      "entityName": "mpg$Car"
-    },
-    "editComponentName": "mpg-car-edit",
-    "entity": {
-      "name": "mpg$Car"
     }
   },
   "queryResults": {

--- a/packages/front-generator/src/test/fixtures/react-client/src/app/entity-management/CarEditLowCase.tsx
+++ b/packages/front-generator/src/test/fixtures/react-client/src/app/entity-management/CarEditLowCase.tsx
@@ -1,0 +1,345 @@
+import * as React from "react";
+import { FormEvent } from "react";
+import { Alert, Button, Card, Form, message } from "antd";
+import { observer } from "mobx-react";
+import { CarManagementLowCase } from "./CarManagementLowCase";
+import { FormComponentProps } from "antd/lib/form";
+import { Link, Redirect } from "react-router-dom";
+import { IReactionDisposer, observable, reaction, toJS } from "mobx";
+import {
+  FormattedMessage,
+  injectIntl,
+  WrappedComponentProps
+} from "react-intl";
+
+import {
+  collection,
+  instance,
+  MainStoreInjected,
+  injectMainStore
+} from "@cuba-platform/react-core";
+
+import {
+  Field,
+  withLocalizedForm,
+  extractServerValidationErrors,
+  constructFieldsWithErrors,
+  clearFieldErrors,
+  MultilineText,
+  Spinner
+} from "@cuba-platform/react-ui";
+
+import "app/App.css";
+
+import { Car } from "cuba/entities/mpg$Car";
+import { Garage } from "cuba/entities/mpg$Garage";
+import { TechnicalCertificate } from "cuba/entities/mpg$TechnicalCertificate";
+import { FileDescriptor } from "cuba/entities/base/sys$FileDescriptor";
+
+type Props = FormComponentProps & EditorProps & MainStoreInjected;
+
+type EditorProps = {
+  entityId: string;
+};
+
+@injectMainStore
+@observer
+class CarEditLowCaseComponent extends React.Component<
+  Props & WrappedComponentProps
+> {
+  dataInstance = instance<Car>(Car.NAME, {
+    view: "car-edit",
+    loadImmediately: false
+  });
+
+  garagesDc = collection<Garage>(Garage.NAME, { view: "_minimal" });
+
+  technicalCertificatesDc = collection<TechnicalCertificate>(
+    TechnicalCertificate.NAME,
+    { view: "_minimal" }
+  );
+
+  photosDc = collection<FileDescriptor>(FileDescriptor.NAME, {
+    view: "_minimal"
+  });
+
+  @observable updated = false;
+  reactionDisposer: IReactionDisposer;
+
+  fields = [
+    "manufacturer",
+    "model",
+    "regNumber",
+    "purchaseDate",
+    "manufactureDate",
+    "wheelOnRight",
+    "carType",
+    "ecoRank",
+    "maxPassengers",
+    "price",
+    "mileage",
+    "garage",
+    "technicalCertificate",
+    "photo"
+  ];
+
+  @observable globalErrors: string[] = [];
+
+  handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    this.props.form.validateFields((err, values) => {
+      if (err) {
+        message.error(
+          this.props.intl.formatMessage({
+            id: "management.editor.validationError"
+          })
+        );
+        return;
+      }
+      this.dataInstance
+        .update(this.props.form.getFieldsValue(this.fields))
+        .then(() => {
+          message.success(
+            this.props.intl.formatMessage({ id: "management.editor.success" })
+          );
+          this.updated = true;
+        })
+        .catch((e: any) => {
+          if (e.response && typeof e.response.json === "function") {
+            e.response.json().then((response: any) => {
+              clearFieldErrors(this.props.form);
+              const {
+                globalErrors,
+                fieldErrors
+              } = extractServerValidationErrors(response);
+              this.globalErrors = globalErrors;
+              if (fieldErrors.size > 0) {
+                this.props.form.setFields(
+                  constructFieldsWithErrors(fieldErrors, this.props.form)
+                );
+              }
+
+              if (fieldErrors.size > 0 || globalErrors.length > 0) {
+                message.error(
+                  this.props.intl.formatMessage({
+                    id: "management.editor.validationError"
+                  })
+                );
+              } else {
+                message.error(
+                  this.props.intl.formatMessage({
+                    id: "management.editor.error"
+                  })
+                );
+              }
+            });
+          } else {
+            message.error(
+              this.props.intl.formatMessage({ id: "management.editor.error" })
+            );
+          }
+        });
+    });
+  };
+
+  render() {
+    if (this.updated) {
+      return <Redirect to={CarManagementLowCase.PATH} />;
+    }
+
+    const { status } = this.dataInstance;
+    const { mainStore } = this.props;
+    if (mainStore == null || !mainStore.isEntityDataLoaded()) {
+      return <Spinner />;
+    }
+
+    return (
+      <Card className="narrow-layout">
+        <Form onSubmit={this.handleSubmit} layout="vertical">
+          <Field
+            entityName={Car.NAME}
+            propertyName="manufacturer"
+            form={this.props.form}
+            formItemOpts={{ style: { marginBottom: "12px" } }}
+            getFieldDecoratorOpts={{
+              rules: [{ required: true }]
+            }}
+          />
+
+          <Field
+            entityName={Car.NAME}
+            propertyName="model"
+            form={this.props.form}
+            formItemOpts={{ style: { marginBottom: "12px" } }}
+            getFieldDecoratorOpts={{}}
+          />
+
+          <Field
+            entityName={Car.NAME}
+            propertyName="regNumber"
+            form={this.props.form}
+            formItemOpts={{ style: { marginBottom: "12px" } }}
+            getFieldDecoratorOpts={{}}
+          />
+
+          <Field
+            entityName={Car.NAME}
+            propertyName="purchaseDate"
+            form={this.props.form}
+            formItemOpts={{ style: { marginBottom: "12px" } }}
+            getFieldDecoratorOpts={{}}
+          />
+
+          <Field
+            entityName={Car.NAME}
+            propertyName="manufactureDate"
+            form={this.props.form}
+            formItemOpts={{ style: { marginBottom: "12px" } }}
+            getFieldDecoratorOpts={{}}
+          />
+
+          <Field
+            entityName={Car.NAME}
+            propertyName="wheelOnRight"
+            form={this.props.form}
+            formItemOpts={{ style: { marginBottom: "12px" } }}
+            getFieldDecoratorOpts={{
+              valuePropName: "checked"
+            }}
+          />
+
+          <Field
+            entityName={Car.NAME}
+            propertyName="carType"
+            form={this.props.form}
+            formItemOpts={{ style: { marginBottom: "12px" } }}
+            getFieldDecoratorOpts={{
+              rules: [{ required: true }]
+            }}
+          />
+
+          <Field
+            entityName={Car.NAME}
+            propertyName="ecoRank"
+            form={this.props.form}
+            formItemOpts={{ style: { marginBottom: "12px" } }}
+            getFieldDecoratorOpts={{}}
+          />
+
+          <Field
+            entityName={Car.NAME}
+            propertyName="maxPassengers"
+            form={this.props.form}
+            formItemOpts={{ style: { marginBottom: "12px" } }}
+            getFieldDecoratorOpts={{}}
+          />
+
+          <Field
+            entityName={Car.NAME}
+            propertyName="price"
+            form={this.props.form}
+            formItemOpts={{ style: { marginBottom: "12px" } }}
+            getFieldDecoratorOpts={{}}
+          />
+
+          <Field
+            entityName={Car.NAME}
+            propertyName="mileage"
+            form={this.props.form}
+            formItemOpts={{ style: { marginBottom: "12px" } }}
+            getFieldDecoratorOpts={{}}
+          />
+
+          <Field
+            entityName={Car.NAME}
+            propertyName="garage"
+            form={this.props.form}
+            formItemOpts={{ style: { marginBottom: "12px" } }}
+            optionsContainer={this.garagesDc}
+            getFieldDecoratorOpts={{}}
+          />
+
+          <Field
+            entityName={Car.NAME}
+            propertyName="technicalCertificate"
+            form={this.props.form}
+            formItemOpts={{ style: { marginBottom: "12px" } }}
+            optionsContainer={this.technicalCertificatesDc}
+            getFieldDecoratorOpts={{}}
+          />
+
+          <Field
+            entityName={Car.NAME}
+            propertyName="photo"
+            form={this.props.form}
+            formItemOpts={{ style: { marginBottom: "12px" } }}
+            optionsContainer={this.photosDc}
+            getFieldDecoratorOpts={{}}
+          />
+
+          {this.globalErrors.length > 0 && (
+            <Alert
+              message={<MultilineText lines={toJS(this.globalErrors)} />}
+              type="error"
+              style={{ marginBottom: "24px" }}
+            />
+          )}
+
+          <Form.Item style={{ textAlign: "center" }}>
+            <Link to={CarManagementLowCase.PATH}>
+              <Button htmlType="button">
+                <FormattedMessage id="management.editor.cancel" />
+              </Button>
+            </Link>
+            <Button
+              type="primary"
+              htmlType="submit"
+              disabled={status !== "DONE" && status !== "ERROR"}
+              loading={status === "LOADING"}
+              style={{ marginLeft: "8px" }}
+            >
+              <FormattedMessage id="management.editor.submit" />
+            </Button>
+          </Form.Item>
+        </Form>
+      </Card>
+    );
+  }
+
+  componentDidMount() {
+    if (this.props.entityId !== CarManagementLowCase.NEW_SUBPATH) {
+      this.dataInstance.load(this.props.entityId);
+    } else {
+      this.dataInstance.setItem(new Car());
+    }
+    this.reactionDisposer = reaction(
+      () => {
+        return this.dataInstance.item;
+      },
+      () => {
+        this.props.form.setFieldsValue(
+          this.dataInstance.getFieldValues(this.fields)
+        );
+      }
+    );
+  }
+
+  componentWillUnmount() {
+    this.reactionDisposer();
+  }
+}
+
+export default injectIntl(
+  withLocalizedForm<EditorProps>({
+    onValuesChange: (props: any, changedValues: any) => {
+      // Reset server-side errors when field is edited
+      Object.keys(changedValues).forEach((fieldName: string) => {
+        props.form.setFields({
+          [fieldName]: {
+            value: changedValues[fieldName]
+          }
+        });
+      });
+    }
+  })(CarEditLowCaseComponent)
+);

--- a/packages/front-generator/src/test/fixtures/react-client/src/app/entity-management/CarManagementLowCase.tsx
+++ b/packages/front-generator/src/test/fixtures/react-client/src/app/entity-management/CarManagementLowCase.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { RouteComponentProps } from "react-router";
+import { observer } from "mobx-react";
+import CarEditLowCase from "./CarEditLowCase";
+import CarTableLowCase from "./CarTableLowCase";
+import { PaginationConfig } from "antd/es/pagination";
+import { action, observable } from "mobx";
+import {
+  addPagingParams,
+  createPagingConfig,
+  defaultPagingConfig
+} from "@cuba-platform/react-ui";
+
+type Props = RouteComponentProps<{ entityId?: string }>;
+
+@observer
+export class CarManagementLowCase extends React.Component<Props> {
+  static PATH = "/carManagementLowCase";
+  static NEW_SUBPATH = "new";
+
+  @observable paginationConfig: PaginationConfig = { ...defaultPagingConfig };
+
+  componentDidMount(): void {
+    // to disable paging config pass 'true' as disabled param in function below
+    this.paginationConfig = createPagingConfig(this.props.location.search);
+  }
+
+  render() {
+    const { entityId } = this.props.match.params;
+    return entityId ? (
+      <CarEditLowCase entityId={entityId} />
+    ) : (
+      <CarTableLowCase />
+    );
+  }
+
+  @action onPagingChange = (current: number, pageSize: number) => {
+    this.props.history.push(
+      addPagingParams("carManagementLowCase", current, pageSize)
+    );
+    this.paginationConfig = { ...this.paginationConfig, current, pageSize };
+  };
+}

--- a/packages/front-generator/src/test/fixtures/react-client/src/app/entity-management/CarTableLowCase.tsx
+++ b/packages/front-generator/src/test/fixtures/react-client/src/app/entity-management/CarTableLowCase.tsx
@@ -1,0 +1,148 @@
+import * as React from "react";
+import { observer } from "mobx-react";
+import { Link } from "react-router-dom";
+import { observable } from "mobx";
+import { Modal, Button } from "antd";
+
+import {
+  collection,
+  injectMainStore,
+  MainStoreInjected
+} from "@cuba-platform/react-core";
+import { DataTable, Spinner } from "@cuba-platform/react-ui";
+
+import { Car } from "cuba/entities/mpg$Car";
+import { SerializedEntity } from "@cuba-platform/rest";
+import { CarManagementLowCase } from "./CarManagementLowCase";
+import {
+  FormattedMessage,
+  injectIntl,
+  WrappedComponentProps
+} from "react-intl";
+
+@injectMainStore
+@observer
+class CarTableLowCaseComponent extends React.Component<
+  MainStoreInjected & WrappedComponentProps
+> {
+  dataCollection = collection<Car>(Car.NAME, {
+    view: "car-edit",
+    sort: "-updateTs"
+  });
+  @observable selectedRowKey: string | undefined;
+
+  fields = [
+    "manufacturer",
+    "model",
+    "regNumber",
+    "purchaseDate",
+    "manufactureDate",
+    "wheelOnRight",
+    "carType",
+    "ecoRank",
+    "maxPassengers",
+    "price",
+    "mileage",
+    "garage",
+    "technicalCertificate",
+    "photo"
+  ];
+
+  showDeletionDialog = (e: SerializedEntity<Car>) => {
+    Modal.confirm({
+      title: this.props.intl.formatMessage(
+        { id: "management.browser.delete.areYouSure" },
+        { instanceName: e._instanceName }
+      ),
+      okText: this.props.intl.formatMessage({
+        id: "management.browser.delete.ok"
+      }),
+      cancelText: this.props.intl.formatMessage({
+        id: "management.browser.delete.cancel"
+      }),
+      onOk: () => {
+        this.selectedRowKey = undefined;
+        return this.dataCollection.delete(e);
+      }
+    });
+  };
+
+  render() {
+    if (this.props.mainStore?.isEntityDataLoaded() !== true) return <Spinner />;
+
+    const buttons = [
+      <Link
+        to={CarManagementLowCase.PATH + "/" + CarManagementLowCase.NEW_SUBPATH}
+        key="create"
+      >
+        <Button
+          htmlType="button"
+          style={{ margin: "0 12px 12px 0" }}
+          type="primary"
+          icon="plus"
+        >
+          <span>
+            <FormattedMessage id="management.browser.create" />
+          </span>
+        </Button>
+      </Link>,
+      <Link
+        to={CarManagementLowCase.PATH + "/" + this.selectedRowKey}
+        key="edit"
+      >
+        <Button
+          htmlType="button"
+          style={{ margin: "0 12px 12px 0" }}
+          disabled={!this.selectedRowKey}
+          type="default"
+        >
+          <FormattedMessage id="management.browser.edit" />
+        </Button>
+      </Link>,
+      <Button
+        htmlType="button"
+        style={{ margin: "0 12px 12px 0" }}
+        disabled={!this.selectedRowKey}
+        onClick={this.deleteSelectedRow}
+        key="remove"
+        type="default"
+      >
+        <FormattedMessage id="management.browser.remove" />
+      </Button>
+    ];
+
+    return (
+      <DataTable
+        dataCollection={this.dataCollection}
+        fields={this.fields}
+        onRowSelectionChange={this.handleRowSelectionChange}
+        hideSelectionColumn={true}
+        buttons={buttons}
+      />
+    );
+  }
+
+  getRecordById(id: string): SerializedEntity<Car> {
+    const record:
+      | SerializedEntity<Car>
+      | undefined = this.dataCollection.items.find(record => record.id === id);
+
+    if (!record) {
+      throw new Error("Cannot find entity with id " + id);
+    }
+
+    return record;
+  }
+
+  handleRowSelectionChange = (selectedRowKeys: string[]) => {
+    this.selectedRowKey = selectedRowKeys[0];
+  };
+
+  deleteSelectedRow = () => {
+    this.showDeletionDialog(this.getRecordById(this.selectedRowKey!));
+  };
+}
+
+const CarTableLowCase = injectIntl(CarTableLowCaseComponent);
+
+export default CarTableLowCase;

--- a/packages/front-generator/src/test/generators/react-typrscript/react-generator-process-templates.test.ts
+++ b/packages/front-generator/src/test/generators/react-typrscript/react-generator-process-templates.test.ts
@@ -37,8 +37,8 @@ class CopyTplGenerator extends Base {
     ];
 
     const model = {
-      editComponentName: "CarEdit",
-      listComponentName: "CarCards",
+      editComponentClass: "CarEdit",
+      listComponentClass: "CarCards",
       className: "CarManagement",
       editAssociations: {
         garage: {className: 'Garage', path: 'cuba/entities/scr$Garage'}

--- a/packages/front-generator/src/test/generators/react-typrscript/react-generator.test.ts
+++ b/packages/front-generator/src/test/generators/react-typrscript/react-generator.test.ts
@@ -3,7 +3,7 @@ import {generate} from "../../../init";
 import * as path from "path";
 import {promisify} from "util";
 import * as fs from "fs";
-import {assertContent, assertFiles, opts} from '../../test-commons';
+import {assertFiles, opts} from '../../test-commons';
 
 const rimraf = promisify(require('rimraf'));
 
@@ -37,6 +37,13 @@ describe('react generator test', () => {
       opts(COMPONENT_DIR, answers.blankComponent, modelPath));
 
     assertFiles('src/app/component/BlankComponent.tsx', REACT_DIR, FIXTURES_DIR);
+
+    await rimraf(`${COMPONENT_DIR}/*`);
+
+    await generate('react-typescript', 'blank-component',
+      opts(COMPONENT_DIR, answers.blankComponentLowCase, modelPath));
+
+    assertFiles('src/app/component/BlankComponent.tsx', REACT_DIR, FIXTURES_DIR);
   });
 
   it('should generate React client entity-cards', async function () {
@@ -59,12 +66,18 @@ describe('react generator test', () => {
       opts(EM_DIR, answers.entityManagement2, modelPath));
     await generate('react-typescript', 'entity-management',
       opts(EM_DIR, answers.entityManagement3, modelPath));
+    await generate('react-typescript', 'entity-management',
+      opts(EM_DIR, answers.entityManagementLowCase, modelPath));
 
     assertFiles('src/app/entity-management/CarCards.tsx', REACT_DIR, FIXTURES_DIR);
     assertFiles('src/app/entity-management/CarEdit.tsx', REACT_DIR, FIXTURES_DIR);
     assertFiles('src/app/entity-management/CarList.tsx', REACT_DIR, FIXTURES_DIR);
     assertFiles('src/app/entity-management/CarTable.tsx', REACT_DIR, FIXTURES_DIR);
     assertFiles('src/app/entity-management/CarManagement.tsx', REACT_DIR, FIXTURES_DIR);
+
+    assertFiles('src/app/entity-management/CarManagementLowCase.tsx', REACT_DIR, FIXTURES_DIR);
+    assertFiles('src/app/entity-management/CarEditLowCase.tsx', REACT_DIR, FIXTURES_DIR);
+    assertFiles('src/app/entity-management/CarTableLowCase.tsx', REACT_DIR, FIXTURES_DIR);
   });
 
 });


### PR DESCRIPTION
affects: @cuba-platform/front-generator

generate editor and list classes and files always from capital letter and in camel case notation

relates: #201

BREAKING CHANGE:
component generation - names of component classes and files will be generated in camel case notation with first capital letter