### PR TITLE
Default sort fail if entity not implements updatable

### DIFF
--- a/.snyk-react-client-scr
+++ b/.snyk-react-client-scr
@@ -10486,4 +10486,12 @@ ignore:
     - react-scripts > webpack-dev-server > yargs > yargs-parser:
         reason: No upgrade available
         expires: '2020-06-07T16:29:29.193Z'
+  SNYK-JS-SERIALIZEJAVASCRIPT-570062:
+    - react-scripts > terser-webpack-plugin > serialize-javascript:
+        reason: No upgrade available
+        expires: '2020-07-03T08:56:04.065Z'
+    - react-scripts > webpack > terser-webpack-plugin > serialize-javascript:
+        reason: No upgrade available
+        expires: '2020-07-03T08:56:04.065Z'
+# patches apply the minimum changes required to fix a vulnerability
 patch: {}

--- a/packages/front-generator/src/generators/react-typescript/entity-management/template/Cards.tsx.ejs
+++ b/packages/front-generator/src/generators/react-typescript/entity-management/template/Cards.tsx.ejs
@@ -38,7 +38,9 @@ class <%= listComponentClass %>Component extends React.Component<Props> {
 
   dataCollection = collection<<%= entity.className %>>(<%= entity.className %>.NAME, {
     view: '<%= listView.name %>',
-    sort: '-updateTs',
+    <% if (entity.updatable == true) { -%>
+      sort: '-updateTs',
+    <% } %>
     loadImmediately: false
   });
 

--- a/packages/front-generator/src/generators/react-typescript/entity-management/template/List.tsx.ejs
+++ b/packages/front-generator/src/generators/react-typescript/entity-management/template/List.tsx.ejs
@@ -26,7 +26,9 @@ class <%= listComponentClass %>Component extends React.Component<Props> {
 
   dataCollection = collection<<%= entity.className %>>(<%= entity.className %>.NAME, {
     view: '<%= listView.name %>',
-    sort: '-updateTs',
+    <% if (entity.updatable == true) { -%>
+      sort: '-updateTs',
+    <% } %>
     loadImmediately: false
   });
 

--- a/packages/front-generator/src/generators/react-typescript/entity-management/template/Table.tsx.ejs
+++ b/packages/front-generator/src/generators/react-typescript/entity-management/template/Table.tsx.ejs
@@ -16,7 +16,12 @@ import {FormattedMessage, injectIntl, WrappedComponentProps} from 'react-intl';
 @observer
 class <%= listComponentClass %>Component extends React.Component<MainStoreInjected & WrappedComponentProps> {
 
-  dataCollection = collection<<%= entity.className %>>(<%= entity.className %>.NAME, {view: '<%= listView.name %>', sort: '-updateTs'});
+  dataCollection = collection<<%= entity.className %>>(<%= entity.className %>.NAME, {
+      view: '<%= listView.name %>',
+      <% if (entity.updatable == true) { -%>
+        sort: '-updateTs',
+      <% } %>
+    });
   @observable selectedRowKey: string | undefined;
 
   fields = [

--- a/packages/front-generator/src/test/fixtures/mpg-projectModel.json
+++ b/packages/front-generator/src/test/fixtures/mpg-projectModel.json
@@ -145,7 +145,7 @@
       "packageName": "com.company.mpg.entity",
       "dataStore": "_MAIN_",
       "table": "MPG_CAR",
-      "updatable": false,
+      "updatable": true,
       "creatable": false,
       "hasUuid": false,
       "softDelete": false,


### PR DESCRIPTION


affects: @cuba-platform/front-generator

entity browsers sort will not applied for non-updatable entities

relates: #120

BREAKING CHANGE:
entity browser sort will not applied for projects generated in Studio before 13 version| studio 12 has an issue with correct defining updatable for entities in project model