### PR TITLE
fix: react-native:app asks to select the project twice

### DIFF
--- a/packages/front-generator/src/generators/react-native/app/index.ts
+++ b/packages/front-generator/src/generators/react-native/app/index.ts
@@ -67,7 +67,7 @@ class ReactNativeAppGenerator extends BaseGenerator<ReactNativeAnswers, ReactNat
     this.log(`Generating SDK model and services in ${sdkDest}`);
 
     const sdkOpts = {
-      model: this.modelPath,
+      model: this.modelFilePath,
       dest: sdkDest
     };
 


### PR DESCRIPTION
affects: @cuba-platform/front-generator

related to #230