### PR TITLE
fix: layout breaks when side menu is bigger than the viewport

### DIFF
--- a/packages/front-generator/src/generators/react-typescript/app/template/src/index.css
+++ b/packages/front-generator/src/generators/react-typescript/app/template/src/index.css
@@ -1,7 +1,3 @@
-html, body, #root {
-  height: 100%;
-}
-
 body {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
affects: @cuba-platform/front-generator

related to #210