### PR TITLE
setup analytics on the documentation site

### DIFF
--- a/docs-src/supplemental-ui/partials/footer-scripts.hbs
+++ b/docs-src/supplemental-ui/partials/footer-scripts.hbs
@@ -1,6 +1,13 @@
 <!--This Source Code Form is subject to the terms of the Mozilla Public-->
 <!--License, v. 2.0. If a copy of the MPL was not distributed with this-->
 <!--file, You can obtain one at http://mozilla.org/MPL/2.0/.-->
+{{#with site.keys.googleAnalytics}}
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{this}}"
+                      height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    </noscript>
+    <!-- End Google Tag Manager (noscript) -->
+{{/with}}
 <script src="{{uiRootPath}}/js/site.js"></script>
 <script async src="{{uiRootPath}}/js/vendor/highlight.js"></script>
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>

--- a/docs-src/supplemental-ui/partials/footer-scripts.hbs
+++ b/docs-src/supplemental-ui/partials/footer-scripts.hbs
@@ -1,6 +1,6 @@
-<!--This Source Code Form is subject to the terms of the Mozilla Public-->
-<!--License, v. 2.0. If a copy of the MPL was not distributed with this-->
-<!--file, You can obtain one at http://mozilla.org/MPL/2.0/.-->
+{{! This Source Code Form is subject to the terms of the Mozilla Public }}
+{{! License, v. 2.0. If a copy of the MPL was not distributed with this }}
+{{! file, You can obtain one at http://mozilla.org/MPL/2.0/. }}
 {{#with site.keys.googleAnalytics}}
     <!-- Google Tag Manager (noscript) -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{this}}"

--- a/docs-src/supplemental-ui/partials/head-scripts.hbs
+++ b/docs-src/supplemental-ui/partials/head-scripts.hbs
@@ -1,0 +1,12 @@
+<!--This Source Code Form is subject to the terms of the Mozilla Public-->
+<!--License, v. 2.0. If a copy of the MPL was not distributed with this-->
+<!--file, You can obtain one at http://mozilla.org/MPL/2.0/.-->
+{{#with site.keys.googleAnalytics}}
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+                new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','{{this}}');</script>
+    <!-- End Google Tag Manager -->
+{{/with}}

--- a/docs-src/supplemental-ui/partials/head-scripts.hbs
+++ b/docs-src/supplemental-ui/partials/head-scripts.hbs
@@ -1,6 +1,6 @@
-<!--This Source Code Form is subject to the terms of the Mozilla Public-->
-<!--License, v. 2.0. If a copy of the MPL was not distributed with this-->
-<!--file, You can obtain one at http://mozilla.org/MPL/2.0/.-->
+{{! This Source Code Form is subject to the terms of the Mozilla Public }}
+{{! License, v. 2.0. If a copy of the MPL was not distributed with this }}
+{{! file, You can obtain one at http://mozilla.org/MPL/2.0/. }}
 {{#with site.keys.googleAnalytics}}
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/docs-src/supplemental-ui/partials/head-styles.hbs
+++ b/docs-src/supplemental-ui/partials/head-styles.hbs
@@ -1,5 +1,5 @@
-<!--This Source Code Form is subject to the terms of the Mozilla Public-->
-<!--License, v. 2.0. If a copy of the MPL was not distributed with this-->
-<!--file, You can obtain one at http://mozilla.org/MPL/2.0/.-->
+{{! This Source Code Form is subject to the terms of the Mozilla Public }}
+{{! License, v. 2.0. If a copy of the MPL was not distributed with this }}
+{{! file, You can obtain one at http://mozilla.org/MPL/2.0/. }}
 <link rel="stylesheet" href="{{uiRootPath}}/css/site.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />

--- a/docs-src/supplemental-ui/partials/header-content.hbs
+++ b/docs-src/supplemental-ui/partials/header-content.hbs
@@ -1,6 +1,6 @@
-<!--This Source Code Form is subject to the terms of the Mozilla Public-->
-<!--License, v. 2.0. If a copy of the MPL was not distributed with this-->
-<!--file, You can obtain one at http://mozilla.org/MPL/2.0/.-->
+{{! This Source Code Form is subject to the terms of the Mozilla Public }}
+{{! License, v. 2.0. If a copy of the MPL was not distributed with this }}
+{{! file, You can obtain one at http://mozilla.org/MPL/2.0/. }}
 <style>
     .cuba-header.navbar {
         background: #0b6ec7;


### PR DESCRIPTION
use Tag Manager instead of Global Site Tag

ISSUES CLOSED: #263