### PR TITLE
Revert "fix: layout breaks when side menu is bigger than the viewport"

### DIFF
--- a/packages/front-generator/src/generators/react-typescript/app/template/src/index.css
+++ b/packages/front-generator/src/generators/react-typescript/app/template/src/index.css
@@ -1,3 +1,7 @@
+html, body, #root {
+  height: 100%;
+}
+
 body {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
This reverts commit 9378b9556632df4747f38381b811bfdae54ef5db.