### PR TITLE
fix(Front Generator): fix model relative path used in ejs templates

### DIFF
--- a/packages/front-generator/src/common/utils.ts
+++ b/packages/front-generator/src/common/utils.ts
@@ -50,5 +50,17 @@ export function getEntityModulePath(entity: Entity, prefix: string = ''): string
   return path.posix.join(prefix, modulePath);
 }
 
+export function isBlank(str: string | undefined): boolean {
+  return (str == null || /^\s*$/.test(str));
+}
+
+/**
+ * Verify that trailing slash exist in relPath
+ * @param relPath
+ */
+export function normalizeRelativePath(relPath: string | undefined): string {
+  return isBlank(relPath) ? '' : path.join(relPath!, '/');
+}
+
 
 

--- a/packages/front-generator/src/generators/polymer2/blank-component/index.ts
+++ b/packages/front-generator/src/generators/polymer2/blank-component/index.ts
@@ -4,7 +4,7 @@ import {blankComponentParams} from "./params";
 import {Polymer2ComponentTemplateModel} from "./template-model";
 import {BaseGenerator} from "../../../common/base-generator";
 import {StudioTemplateProperty} from "../../../common/studio/studio-model";
-import {elementNameToClass} from "../../../common/utils";
+import {elementNameToClass, normalizeRelativePath} from "../../../common/utils";
 
 export interface BlankComponentAnswers {
   componentName: string
@@ -54,7 +54,7 @@ export function blankComponentAnswersToModel(answers: BlankComponentAnswers, dir
   return {
     componentName: answers.componentName,
     className: elementNameToClass(answers.componentName),
-    relDirShift: dirShift || ''
+    relDirShift: normalizeRelativePath(dirShift)
   }
 }
 

--- a/packages/front-generator/src/generators/polymer2/entity-cards/index.ts
+++ b/packages/front-generator/src/generators/polymer2/entity-cards/index.ts
@@ -4,7 +4,7 @@ import {OptionsConfig, PolymerElementOptions, polymerElementOptionsConfig} from 
 import {StudioTemplateProperty} from "../../../common/studio/studio-model";
 import * as path from "path";
 import {EntityCardsTemplateModel} from "./template-model";
-import {elementNameToClass} from "../../../common/utils";
+import {elementNameToClass, normalizeRelativePath} from "../../../common/utils";
 
 
 class EntityCardsGenerator extends BaseGenerator<EntityCardsAnswers, EntityCardsTemplateModel, PolymerElementOptions> {
@@ -49,7 +49,7 @@ export function entityCardsAnswersToModel(answers: EntityCardsAnswers, dirShift:
   return {
     componentName: answers.componentName,
     className: elementNameToClass(answers.componentName),
-    relDirShift: dirShift || '',
+    relDirShift: normalizeRelativePath(dirShift),
     entity: answers.entity,
     view: answers.entityView
   }

--- a/packages/front-generator/src/generators/polymer2/entity-edit/index.ts
+++ b/packages/front-generator/src/generators/polymer2/entity-edit/index.ts
@@ -4,7 +4,7 @@ import {StudioTemplateProperty} from "../../../common/studio/studio-model";
 import {EntityEditAnswers, entityEditParams} from "./params";
 import {EntityEditTemplateModel} from "./template-model";
 import * as path from "path";
-import {elementNameToClass} from "../../../common/utils";
+import {elementNameToClass, normalizeRelativePath} from "../../../common/utils";
 import {Entity, EntityAttribute, View} from "../../../common/model/cuba-model";
 import {fieldDependencies, FieldModel, getFieldHtml, getFieldModel} from "../common/fields";
 
@@ -83,7 +83,7 @@ export function entityEditAnswersToModel(answers: EntityEditAnswers, dirShift: s
     imports,
     componentName: answers.editComponentName,
     className: elementNameToClass(answers.editComponentName),
-    relDirShift: dirShift || '',
+    relDirShift: normalizeRelativePath(dirShift),
     view: answers.editView,
     entity: answers.entity,
   }

--- a/packages/front-generator/src/generators/polymer2/entity-list/index.ts
+++ b/packages/front-generator/src/generators/polymer2/entity-list/index.ts
@@ -4,7 +4,7 @@ import {StudioTemplateProperty} from "../../../common/studio/studio-model";
 import {OptionsConfig, PolymerElementOptions, polymerElementOptionsConfig} from "../../../common/cli-options";
 import {EntityListTemplateModel} from "./template-model";
 import * as path from "path";
-import {elementNameToClass} from "../../../common/utils";
+import {elementNameToClass, normalizeRelativePath} from "../../../common/utils";
 
 class EntityListGenerator extends BaseGenerator<EntityListAnswers, EntityListTemplateModel, PolymerElementOptions> {
 
@@ -48,7 +48,7 @@ export function entityListAnswersToModel(answers: EntityListAnswers, dirShift: s
   return {
     componentName: answers.componentName,
     className: elementNameToClass(answers.componentName),
-    relDirShift: dirShift || '',
+    relDirShift: normalizeRelativePath(dirShift),
     entity: answers.entity,
     view: answers.entityView
   }

--- a/packages/front-generator/src/generators/polymer2/entity-management/index.ts
+++ b/packages/front-generator/src/generators/polymer2/entity-management/index.ts
@@ -4,7 +4,7 @@ import {OptionsConfig, PolymerElementOptions, polymerElementOptionsConfig} from 
 import {EntityManagementTemplateModel} from "./template-model";
 import * as path from "path";
 import {StudioTemplateProperty} from "../../../common/studio/studio-model";
-import {elementNameToClass} from "../../../common/utils";
+import {elementNameToClass, normalizeRelativePath} from "../../../common/utils";
 import {EntityListTemplateModel} from "../entity-list/template-model";
 import {EntityCardsTemplateModel} from "../entity-cards/template-model";
 import {EntityEditTemplateModel} from "../entity-edit/template-model";
@@ -60,7 +60,7 @@ export function answersToManagementModel(answers: EntityManagementAnswers, dirSh
   return {
     componentName: answers.managementComponentName,
     className: elementNameToClass(answers.managementComponentName),
-    relDirShift: dirShift || '',
+    relDirShift: normalizeRelativePath(dirShift),
     listComponentName: answers.listComponentName,
     editComponentName: answers.editComponentName,
     listType: answers.listType
@@ -71,7 +71,7 @@ export function answersToListModel(answers: EntityManagementAnswers, dirShift: s
   return {
     componentName: answers.listComponentName,
     className: elementNameToClass(answers.listComponentName),
-    relDirShift: dirShift || '',
+    relDirShift: normalizeRelativePath(dirShift),
     entity: answers.entity,
     view: answers.listView
   }
@@ -84,7 +84,7 @@ export function answersToEditModel(answers: EntityManagementAnswers, dirShift: s
     imports,
     componentName: answers.editComponentName,
     className: elementNameToClass(answers.editComponentName),
-    relDirShift: dirShift || '',
+    relDirShift: normalizeRelativePath(dirShift),
     view: answers.editView,
     entity: answers.entity,
   }

--- a/packages/front-generator/src/generators/polymer2/query-results/index.ts
+++ b/packages/front-generator/src/generators/polymer2/query-results/index.ts
@@ -4,7 +4,7 @@ import {StudioTemplateProperty} from "../../../common/studio/studio-model";
 import {PolymerElementOptions, polymerElementOptionsConfig} from "../../../common/cli-options";
 import {QueryResultsTemplateModel} from "./template-model";
 import * as path from "path";
-import {elementNameToClass} from "../../../common/utils";
+import {elementNameToClass, normalizeRelativePath} from "../../../common/utils";
 import {RestParam} from "../../../common/model/cuba-model";
 import {getRestParamFieldModel} from "../common/fields/rest-params";
 import {getFieldHtml} from "../common/fields";
@@ -62,7 +62,7 @@ function answersToModel(answers: QueryResultAnswers, dirShift: string | undefine
     fields,
     componentName: answers.componentName,
     className: elementNameToClass(answers.componentName),
-    relDirShift: dirShift || '',
+    relDirShift: normalizeRelativePath(dirShift),
     query: answers.query
   };
 }

--- a/packages/front-generator/src/generators/polymer2/service-data/index.ts
+++ b/packages/front-generator/src/generators/polymer2/service-data/index.ts
@@ -4,7 +4,7 @@ import {ServiceDataAnswers, serviceDataParams} from "./params";
 import {PolymerElementOptions, polymerElementOptionsConfig} from "../../../common/cli-options";
 import {ServiceDataTemplateModel} from "./template-model";
 import * as path from "path";
-import {elementNameToClass} from "../../../common/utils";
+import {elementNameToClass, normalizeRelativePath} from "../../../common/utils";
 import {composeParamFields} from "../service-form";
 import {RestService} from "../../../common/model/cuba-model";
 
@@ -51,7 +51,7 @@ function answersToModel(answers: ServiceDataAnswers, dirShift: string | undefine
     fields: composeParamFields(answers.serviceMethod.method.params),
     componentName: answers.componentName,
     className: elementNameToClass(answers.componentName),
-    relDirShift: dirShift || '',
+    relDirShift: normalizeRelativePath(dirShift),
     method: answers.serviceMethod.method,
     service: answers.serviceMethod.service
   };

--- a/packages/front-generator/src/generators/polymer2/service-form/index.ts
+++ b/packages/front-generator/src/generators/polymer2/service-form/index.ts
@@ -4,7 +4,7 @@ import {ServiceFormAnswers, serviceFormParams} from "./params";
 import {ServiceFormTemplateModel} from "./template-model";
 import * as path from "path";
 import {StudioTemplateProperty} from "../../../common/studio/studio-model";
-import {elementNameToClass} from "../../../common/utils";
+import {elementNameToClass, normalizeRelativePath} from "../../../common/utils";
 import {RestParam} from "../../../common/model/cuba-model";
 import {getRestParamFieldModel} from "../common/fields/rest-params";
 import {getFieldHtml} from "../common/fields";
@@ -61,7 +61,7 @@ function answersToModel(answers: ServiceFormAnswers, dirShift: string | undefine
     fields,
     componentName: answers.componentName,
     className: elementNameToClass(answers.componentName),
-    relDirShift: dirShift || '',
+    relDirShift: normalizeRelativePath(dirShift),
     method: answers.serviceMethod.method,
     service: answers.serviceMethod.service
   };

--- a/packages/front-generator/src/generators/react-typescript/blank-component/index.ts
+++ b/packages/front-generator/src/generators/react-typescript/blank-component/index.ts
@@ -3,7 +3,7 @@ import {OptionsConfig, polymerElementOptionsConfig, PolymerElementOptions} from 
 import {blankComponentParams} from "./params";
 import {BaseGenerator} from "../../../common/base-generator";
 import {StudioTemplateProperty} from "../../../common/studio/studio-model";
-import {elementNameToClass, unCapitalizeFirst} from "../../../common/utils";
+import {elementNameToClass, normalizeRelativePath, unCapitalizeFirst} from "../../../common/utils";
 import {CommonTemplateModel} from "../../polymer2/common/template-model";
 import {addToMenu} from "../common/menu";
 
@@ -70,7 +70,7 @@ export function blankComponentAnswersToModel(answers: BlankComponentAnswers, dir
   return {
     className,
     componentName: answers.componentName,
-    relDirShift: dirShift || '',
+    relDirShift: normalizeRelativePath(dirShift),
     nameLiteral: unCapitalizeFirst(className)
   }
 }

--- a/packages/front-generator/src/generators/react-typescript/entity-cards/index.ts
+++ b/packages/front-generator/src/generators/react-typescript/entity-cards/index.ts
@@ -6,7 +6,7 @@ import {
 import {StudioTemplateProperty} from "../../../common/studio/studio-model";
 import * as path from "path";
 import {EntityCardsTemplateModel} from "./template-model";
-import {elementNameToClass, unCapitalizeFirst} from "../../../common/utils";
+import {elementNameToClass, normalizeRelativePath, unCapitalizeFirst} from "../../../common/utils";
 import {addToMenu} from "../common/menu";
 import {writeComponentI18nMessages} from '../common/i18n';
 import {createEntityTemplateModel, getDisplayedAttributes, ScreenType} from "../common/entity";
@@ -104,7 +104,7 @@ export function entityCardsAnswersToModel(
     componentName: answers.componentName,
     className,
     nameLiteral: unCapitalizeFirst(className),
-    relDirShift: dirShift || '',
+    relDirShift: normalizeRelativePath(dirShift),
     entity: answers.entity,
     view: answers.entityView,
     attributes,

--- a/packages/front-generator/src/generators/react-typescript/entity-management/index.ts
+++ b/packages/front-generator/src/generators/react-typescript/entity-management/index.ts
@@ -12,7 +12,7 @@ import {
 import {EditRelations, EditRelationsSplit, EntityManagementTemplateModel, RelationImport} from "./template-model";
 import * as path from "path";
 import {StudioTemplateProperty, StudioTemplatePropertyType, ViewInfo} from "../../../common/studio/studio-model";
-import {capitalizeFirst, elementNameToClass, unCapitalizeFirst} from "../../../common/utils";
+import {capitalizeFirst, elementNameToClass, normalizeRelativePath, unCapitalizeFirst} from "../../../common/utils";
 import {addToMenu} from "../common/menu";
 import {EntityAttribute, ProjectModel} from "../../../common/model/cuba-model";
 import {findEntity, findView} from "../../../common/model/cuba-model-utils";
@@ -178,7 +178,7 @@ function answersToManagementModel(answers: EntityManagementAnswers,
   return {
     componentName: answers.managementComponentName,
     className,
-    relDirShift: dirShift || '',
+    relDirShift: normalizeRelativePath(dirShift),
     listComponentClass: elementNameToClass(answers.listComponentName),
     editComponentClass: elementNameToClass(answers.editComponentName),
     listType: answers.listType,

--- a/packages/front-generator/src/test/utils.test.ts
+++ b/packages/front-generator/src/test/utils.test.ts
@@ -1,4 +1,10 @@
-import {convertToUnixPath, elementNameToClass, fqnToName, splitByCapitalLetter} from "../common/utils";
+import {
+  convertToUnixPath,
+  elementNameToClass,
+  fqnToName,
+  normalizeRelativePath,
+  splitByCapitalLetter
+} from "../common/utils";
 import * as assert from "assert";
 import { expect } from "chai";
 
@@ -28,6 +34,20 @@ describe('utils', () => {
     expect(splitByCapitalLetter('split123It')).eq('split123 It');
     expect(splitByCapitalLetter('split$It')).eq('split$ It');
     expect(splitByCapitalLetter('split_It')).eq('split_ It');
+  });
+
+  it('should normalize relative path', () => {
+    expect(normalizeRelativePath("..")).eq("../");
+    expect(normalizeRelativePath("../")).eq("../");
+    expect(normalizeRelativePath("../..")).eq("../../");
+    expect(normalizeRelativePath("../../")).eq("../../");
+    expect(normalizeRelativePath("")).eq("");
+    expect(normalizeRelativePath(".")).eq("./");
+    expect(normalizeRelativePath("./")).eq("./");
+    expect(normalizeRelativePath("./../")).eq("../");
+    expect(normalizeRelativePath("/")).eq("/");
+    expect(normalizeRelativePath("   ")).eq("");
+    expect(normalizeRelativePath(undefined)).eq("");
   });
 
 });


### PR DESCRIPTION
affects: @cuba-platform/front-generator

model relative path, used for import generation in ejs templates must always ends with slash

relates: #268