### PR TITLE
fix: layout breaks when side menu is bigger than the viewport

### DIFF
--- a/packages/front-generator/src/generators/react-typescript/app/template/src/app/App.css
+++ b/packages/front-generator/src/generators/react-typescript/app/template/src/app/App.css
@@ -2,6 +2,10 @@
   height: 100%;
 }
 
+.layout-container.ant-layout {
+  min-height: initial;
+}
+
 .layout-sider {
   background: #ffffff;
 }

--- a/packages/front-generator/src/generators/react-typescript/app/template/src/app/App.tsx
+++ b/packages/front-generator/src/generators/react-typescript/app/template/src/app/App.tsx
@@ -51,7 +51,7 @@ class AppComponent extends React.Component<
         <Layout.Header>
           <AppHeader />
         </Layout.Header>
-        <Layout>
+        <Layout className='layout-container'>
           <Layout.Sider
             width={200}
             breakpoint="sm"


### PR DESCRIPTION
affects: @cuba-platform/front-generator

ticket #210