### PR TITLE
fix(Front Generator): sort only updatable entites on EntityCards

### DIFF
--- a/packages/front-generator/src/generators/react-typescript/entity-cards/template/EntityCards.tsx.ejs
+++ b/packages/front-generator/src/generators/react-typescript/entity-cards/template/EntityCards.tsx.ejs
@@ -24,7 +24,9 @@ export class <%= className %> extends React.Component<Props> {
 
   dataCollection = collection<<%= entity.className %>>(<%= entity.className %>.NAME, {
     view: '<%=view.name%>',
-    sort: '-updateTs',
+    <% if (entity.updatable == true) { -%>
+        sort: '-updateTs',
+    <% } -%>
     loadImmediately: false,
     <% if (locals.stringIdName != null) { %>
       stringIdName: '<%= stringIdName %>'

--- a/packages/front-generator/src/test/fixtures/react-client/src/app/entity-cards/MpgFavoriteCarCards.tsx
+++ b/packages/front-generator/src/test/fixtures/react-client/src/app/entity-cards/MpgFavoriteCarCards.tsx
@@ -28,7 +28,6 @@ type Props = MainStoreInjected & RouteComponentProps;
 export class MpgFavoriteCarCards extends React.Component<Props> {
   dataCollection = collection<FavoriteCar>(FavoriteCar.NAME, {
     view: "favoriteCar-view",
-    sort: "-updateTs",
     loadImmediately: false
   });
 


### PR DESCRIPTION
affects: @cuba-platform/front-generator

before apply default sort by updateTs, check that entity implemets updatable
relates: #120