### PR TITLE
fix: backslashes are written to "import" statements on Windows

### DIFF
--- a/packages/front-generator/src/common/utils.test.ts
+++ b/packages/front-generator/src/common/utils.test.ts
@@ -1,0 +1,17 @@
+import { expect } from "chai";
+import { normalizeRelativePath } from "./utils";
+
+describe('normalizeRelativePath()', () => {
+  it('Replaces the backslashes in the provided path with forward slashes', () => {
+    expect(normalizeRelativePath('..\\..\\')).to.equal('../../');
+    expect(normalizeRelativePath('..\\..')).to.equal('../../');
+  });
+
+  it('Adds a trailing slash if it is missing', () => {
+    expect(normalizeRelativePath('../..')).to.equal('../../');
+  });
+
+  it('Does not add an additional trailing slash if already present', () => {
+    expect(normalizeRelativePath('../../')).to.equal('../../');
+  });
+});

--- a/packages/front-generator/src/common/utils.ts
+++ b/packages/front-generator/src/common/utils.ts
@@ -55,11 +55,17 @@ export function isBlank(str: string | undefined): boolean {
 }
 
 /**
- * Verify that trailing slash exist in relPath
+ * Ensure that the path contains only forward slashes and no backward slashes, and has a trailing forward slash.
+ *
  * @param relPath
  */
 export function normalizeRelativePath(relPath: string | undefined): string {
-  return isBlank(relPath) ? '' : path.join(relPath!, '/');
+  if (relPath == null || isBlank(relPath)) {
+    return '';
+  }
+
+  const relPathPosix = relPath.replace(/\\/g, '/');
+  return path.posix.join(relPathPosix, '/');
 }
 
 


### PR DESCRIPTION
affects: @cuba-platform/front-generator

ticket #293