### PR TITLE
[#286 🡆 master] fix: hide FileUpload drop area when not having sufficient permissions

### DIFF
--- a/docs-src/doc-component-repo/modules/cuba-react-ui/pages/file-upload.adoc
+++ b/docs-src/doc-component-repo/modules/cuba-react-ui/pages/file-upload.adoc
@@ -5,4 +5,29 @@
 
 image:FileUploadAndImagePreviewDemo.gif[FileUpload and ImagePreview demo]
 
+== Permissions
+
+View and download::
+
+User will be able to see the file name and download the file when the following conditions are met:
+
+- User has at least *read-only* permission on the corresponding entity attribute.
+- User has *read* permission on `sys$FileDescriptor` system entity and at least *read-only* permission on its attributes.
+
+Remove::
+
+User will be able to remove the file when the following conditions are met:
+
+- User has *modify* permission on the corresponding entity attribute.
+
+NOTE: "Removing the file" actually doesn't physically remove the file from server. It just removes the association between the entity and the file descriptor.
+
+Upload::
+
+User will be able to upload the file (and link it with the entity) when the following conditions are met:
+
+- User has *modify* permission on the corresponding entity attribute.
+- User has *create* permission on `sys$FileDescriptor` system entity.
+- User has *Upload files using REST API* specific permission.
+
 API: {api_ui_FileUploadProps}[FileUploadProps].

--- a/packages/cuba-react-core/src/app/Security.test.ts
+++ b/packages/cuba-react-core/src/app/Security.test.ts
@@ -1,0 +1,161 @@
+import { Security } from './Security';
+import {EffectivePermsInfo, EntityPermissionValue, Permission} from '@cuba-platform/rest';
+
+describe('Security service', () => {
+  describe('Security#canUploadAndLinkFile()', () => {
+    it('should return true when all permissions are granted explicitly', async () => {
+      expect((await createSecurity()).canUploadAndLinkFile()).toBe(true);
+    });
+
+    it('should return false when create file descriptor permission is denied', async () => {
+      expect((await createSecurity({
+        entities: [{target: 'sys$FileDescriptor:create', value: 0}]
+      })).canUploadAndLinkFile()).toBe(false);
+    });
+
+    it('should return false when create file descriptor permission is undefined and undefined policy is DENY', async () => {
+      expect((await createSecurity({
+        entities: []
+      })).canUploadAndLinkFile()).toBe(false);
+    });
+
+    it('should return true when create file descriptor permission is undefined and undefined policy is ALLOW', async () => {
+      expect((await createSecurity({
+        entities: [],
+        undefinedPermissionPolicy: 'ALLOW'
+      })).canUploadAndLinkFile()).toBe(true);
+    });
+
+    it('should return true when all file descriptor permissions (sys$FileDescriptor:*) are granted', async () => {
+      expect((await createSecurity({
+        entities: [{target: 'sys$FileDescriptor:*', value: 1}]
+      })).canUploadAndLinkFile()).toBe(true);
+    });
+
+    it('should return true when all entity create permissions (*:create) are granted', async () => {
+      expect((await createSecurity({
+        entities: [{target: '*:create', value: 1}]
+      })).canUploadAndLinkFile()).toBe(true);
+    });
+
+    it('should return true when all entity permissions (*:*) are granted', async () => {
+      expect((await createSecurity({
+        entities: [{target: '*:*', value: 1}]
+      })).canUploadAndLinkFile()).toBe(true);
+    });
+
+    it('should return false when upload permission is denied', async () => {
+      expect((await createSecurity({
+        specific: [{target: 'cuba.restApi.fileUpload.enabled', value: 0}]
+      })).canUploadAndLinkFile()).toBe(false);
+    });
+
+    it('should return false when upload permission is undefined, undefined policy is DENY', async () => {
+      expect((await createSecurity({
+        specific: []
+      })).canUploadAndLinkFile()).toBe(false);
+    });
+
+    it('should return true when upload permission is undefined, undefined policy is ALLOW', async () => {
+      expect((await createSecurity({
+        specific: [],
+        undefinedPermissionPolicy: 'ALLOW'
+      })).canUploadAndLinkFile()).toBe(true);
+    });
+
+    it('should return true when all specific permissions are granted', async () => {
+      expect((await createSecurity({
+        specific: [{target: '*', value: 1}]
+      })).canUploadAndLinkFile()).toBe(true);
+    });
+
+    it('should consider entity permissions priority as "from more explicit to less explicit",' +
+      ' i.e.: "scr$Car:read" > "scr$Car:*" > "*:read" > "*:*', async () => {
+      expect((await createSecurity({
+        entities: [
+          {target: '*:*', value: 0},
+          {target: '*:create', value: 0},
+          {target: 'sys$FileDescriptor:*', value: 0},
+          {target: 'sys$FileDescriptor:create', value: 1}
+        ]
+      })).canUploadAndLinkFile()).toBe(true);
+      expect((await createSecurity({
+        entities: [
+          {target: '*:*', value: 0},
+          {target: '*:create', value: 0},
+          {target: 'sys$FileDescriptor:*', value: 1},
+          {target: 'sys$FileDescriptor:create', value: 0}
+        ]
+      })).canUploadAndLinkFile()).toBe(false);
+      expect((await createSecurity({
+        entities: [
+          {target: '*:*', value: 0},
+          {target: '*:create', value: 0},
+          {target: 'sys$FileDescriptor:*', value: 1},
+        ]
+      })).canUploadAndLinkFile()).toBe(true);
+      expect((await createSecurity({
+        entities: [
+          {target: '*:*', value: 0},
+          {target: '*:create', value: 1},
+          {target: 'sys$FileDescriptor:*', value: 0},
+          {target: 'sys$FileDescriptor:create', value: 0}
+        ]
+      })).canUploadAndLinkFile()).toBe(false);
+      expect((await createSecurity({
+        entities: [
+          {target: '*:*', value: 0},
+          {target: '*:create', value: 1},
+        ]
+      })).canUploadAndLinkFile()).toBe(true);
+      expect((await createSecurity({
+        entities: [
+          {target: '*:*', value: 1},
+          {target: '*:create', value: 0},
+          {target: 'sys$FileDescriptor:*', value: 0},
+          {target: 'sys$FileDescriptor:create', value: 0}
+        ]
+      })).canUploadAndLinkFile()).toBe(false);
+    });
+
+    it('should consider specific permissions priority as "explicit permission" > "wildcard"', async () => {
+      expect((await createSecurity({
+        specific: [
+          {target: '*', value: 1},
+          {target: 'cuba.restApi.fileUpload.enabled', value: 0}
+        ]
+      })).canUploadAndLinkFile()).toBe(false);
+      expect((await createSecurity({
+        specific: [
+          {target: '*', value: 0},
+          {target: 'cuba.restApi.fileUpload.enabled', value: 1}
+        ]
+      })).canUploadAndLinkFile()).toBe(true);
+    });
+  });
+});
+
+type PermsMockConfig = {
+  entities?: Array<Permission<EntityPermissionValue>>,
+  specific?: Array<Permission<EntityPermissionValue>>,
+  undefinedPermissionPolicy?: 'ALLOW' | 'DENY'
+};
+
+async function createSecurity(permsMockConfig?: PermsMockConfig): Promise<Security> {
+  const cubaREST = jest.genMockFromModule<any>('@cuba-platform/rest').CubaApp;
+  cubaREST.getEffectivePermissions = jest.fn(() => createPerms(permsMockConfig));
+  const security = new Security(cubaREST);
+  await security.loadPermissions();
+  return security;
+}
+
+function createPerms({entities, specific, undefinedPermissionPolicy}: PermsMockConfig = {}): Promise<EffectivePermsInfo> {
+  return Promise.resolve({
+    explicitPermissions: {
+      entities: entities ?? [{target: 'sys$FileDescriptor:create', value: 1}],
+      entityAttributes: [],
+      specific: specific ?? [{target: 'cuba.restApi.fileUpload.enabled', value: 1}],
+    },
+    undefinedPermissionPolicy: undefinedPermissionPolicy ?? 'DENY'
+  });
+}

--- a/packages/cuba-rest-js/src/cuba.ts
+++ b/packages/cuba-rest-js/src/cuba.ts
@@ -16,6 +16,7 @@ import {base64encode, encodeGetParams, matchesVersion} from "./util";
 export * from './model';
 export * from './storage';
 export * from './filter';
+export * from './security';
 
 const apps: CubaApp[] = [];
 

--- a/packages/cuba-rest-js/src/security.ts
+++ b/packages/cuba-rest-js/src/security.ts
@@ -65,9 +65,37 @@ export function isOperationAllowed(entityName: string,
   explicitPerm = entities.find(perm => perm.target === `${entityName}:*`);
   if (explicitPerm != null) return explicitPerm.value === 1;
 
+  // find entity wildcard perm match '*:read'
+  explicitPerm = entities.find(perm => perm.target === `*:${operation}`);
+  if (explicitPerm != null) return explicitPerm.value === 1;
+
   // find pure wildcard perm match '*:*'
   explicitPerm = entities.find(perm => perm.target === `*:*`);
   if (explicitPerm != null) return explicitPerm.value === 1;
+
+  return perms.undefinedPermissionPolicy === 'ALLOW';
+}
+
+export function isSpecificPermissionGranted(permTarget: string, perms?: EffectivePermsInfo): boolean {
+  if (perms == null) {
+    return false;
+  }
+
+  let wildcardPermValue: EntityPermissionValue;
+
+  for (const perm of perms.explicitPermissions.specific) {
+    if (perm.target === permTarget) {
+      return perm.value === 1;
+    }
+
+    if (perm.target === '*') {
+      wildcardPermValue = perm.value;
+    }
+  }
+
+  if (wildcardPermValue != null) {
+    return wildcardPermValue === 1;
+  }
 
   return perms.undefinedPermissionPolicy === 'ALLOW';
 }

--- a/packages/cuba-rest-js/test/security.spec.js
+++ b/packages/cuba-rest-js/test/security.spec.js
@@ -13,6 +13,10 @@ describe('security', () => {
     expect(security.getAttributePermission('scr$Car', 'mileage', perms))
       .toBe('MODIFY');
 
+    perms.undefinedPermissionPolicy = 'DENY';
+    expect(security.getAttributePermission('scr$Car', 'mileage', perms))
+      .toBe('DENY');
+
     perms.explicitPermissions.entityAttributes.push({target: '*:*', value: 1});
     expect(security.getAttributePermission('scr$Car', 'mileage', perms))
       .toBe('VIEW');
@@ -58,5 +62,52 @@ describe('security', () => {
     expect(security.isOperationAllowed('scr$Car', 'read', perms))
       .toBe(true);
 
+  });
+
+  describe('isSpecificPermissionGranted()', () => {
+    const PERM_NAME = 'cuba.restApi.fileUpload.enabled';
+    let perms;
+
+    beforeEach(() => {
+      perms = {
+        explicitPermissions: {
+          entities: [],
+          entityAttributes: [],
+          specific: []
+        },
+        undefinedPermissionPolicy: 'DENY'
+      };
+    });
+
+    it('should return false for null or undefined perms', () => {
+      expect(security.isSpecificPermissionGranted(PERM_NAME, null)).toBe(false);
+      expect(security.isSpecificPermissionGranted(PERM_NAME, undefined)).toBe(false);
+    });
+
+    it('should return false if no permission is given', () => {
+      expect(security.isSpecificPermissionGranted(PERM_NAME, perms)).toBe(false);
+    });
+
+    it('should return true if wildcard permission is granted', () => {
+      perms.explicitPermissions.specific = [
+        {target: '*', value: 1}
+      ];
+      expect(security.isSpecificPermissionGranted(PERM_NAME, perms)).toBe(true);
+    });
+
+    it('should return true if explicit permission is granted', () => {
+      perms.explicitPermissions.specific = [
+        {target: PERM_NAME, value: 1}
+      ];
+      expect(security.isSpecificPermissionGranted(PERM_NAME, perms)).toBe(true);
+    });
+
+    it('should prefer explicit permission to wildcard', () => {
+      perms.explicitPermissions.specific = [
+        {target: '*', value: 0},
+        {target: PERM_NAME, value: 1}
+      ];
+      expect(security.isSpecificPermissionGranted(PERM_NAME, perms)).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
affects: @cuba-platform/react-core, @cuba-platform/react-ui, @cuba-platform/rest

ticket #286